### PR TITLE
Matrix4x4::CreatePerspective(FieldOfView)LH, with direct SIMD manipulation

### DIFF
--- a/src/Math/Matrix4x4.cpp
+++ b/src/Math/Matrix4x4.cpp
@@ -1,6 +1,7 @@
 #include "Matrix4x4.h"
 
 #include <type_traits>
+#include <cmath>
 
 #include "Vector3.h"
 
@@ -129,6 +130,36 @@ inline Matrix4x4 Matrix4x4::CreateTranslation(const Vector3& position) noexcept
 inline Matrix4x4 Matrix4x4::CreateTranslation(float x, float y, float z) noexcept
 {
     return rtm::matrix_from_translation(vector_set(x, y, z));
+}
+
+Matrix4x4 Matrix4x4::CreatePerspectiveFieldOfViewLH(float fov, float aspectRatio, float nearPlane, float farPlane) noexcept
+{
+    float SinFov = sinf(fov);
+    float CosFov = cosf(fov);
+    float Height = CosFov / SinFov;
+    float Width  = Height / aspectRatio;
+    float fRange = farPlane / (farPlane - nearPlane);
+
+    SIMDValueType m = matrix_set(
+        vector_set(Width, 0.0f, 0.0f, 0.0f),
+        vector_set(0.0f, Height, 0.0f, 0.0f),
+        vector_set(0.0f, 0.0f, fRange, 1.0f),
+        vector_set(0.0f, 0.0f, -fRange * nearPlane, 0.0f));
+    return static_cast<Matrix4x4>(m);
+}
+
+Matrix4x4 Matrix4x4::CreatePerspectiveLH(float width, float height, float nearPlane, float farPlane) noexcept
+{
+    float TwoNearZ = nearPlane + farPlane;
+    float fRange   = farPlane / (farPlane - nearPlane);
+
+    SIMDValueType m = matrix_set(
+        vector_set(TwoNearZ / width, 0.0f, 0.0f, 0.0f),
+        vector_set(0.0f, TwoNearZ / height, 0.0f, 0.0f),
+        vector_set(0.0f, 0.0f, fRange, 1.0f),
+        vector_set(0.0f, 0.0f, -fRange * nearPlane, 0.0f));
+
+    return static_cast<Matrix4x4>(m);
 }
 
 } // namespace gore

--- a/src/Math/Matrix4x4.cpp
+++ b/src/Math/Matrix4x4.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "Vector3.h"
+#include "Vector4.h"
 
 #include "rtm/matrix3x4f.h"
 #include "rtm/matrix4x4f.h"
@@ -22,114 +23,95 @@ std::ostream& operator<<(std::ostream& os, const Matrix4x4& m) noexcept
 
 Matrix4x4::operator SIMDValueType() const noexcept
 {
-    return matrix_set(vector_load(m[0]), vector_load(m[1]), vector_load(m[2]), vector_load(m[3]));
+    return m_M;
 }
 
 Matrix4x4::Matrix4x4(gore::Matrix4x4::SIMDValueType F) noexcept
 {
-    vector_store(matrix_get_axis(F, rtm::axis4::x), m[0]);
-    vector_store(matrix_get_axis(F, rtm::axis4::y), m[1]);
-    vector_store(matrix_get_axis(F, rtm::axis4::z), m[2]);
-    vector_store(matrix_get_axis(F, rtm::axis4::w), m[3]);
+    m_M = F;
 }
 
 Matrix4x4::Matrix4x4(rtm::matrix3x4f&& F) noexcept :
-    _41(0),
-    _42(0),
-    _43(0),
-    _44(1)
+    m_M(matrix_set(
+        matrix_get_axis(F, rtm::axis4::x),
+        matrix_get_axis(F, rtm::axis4::y),
+        matrix_get_axis(F, rtm::axis4::z),
+        vector_set(0.0f, 0.0f, 0.0f, 1.0f)))
 {
-    vector_store(matrix_get_axis(F, rtm::axis4::x), m[0]);
-    vector_store(matrix_get_axis(F, rtm::axis4::y), m[1]);
-    vector_store(matrix_get_axis(F, rtm::axis4::z), m[2]);
 }
 
 // Properties
 Vector3 Matrix4x4::Up() const noexcept
 {
-    return Vector3(_21, _22, _23);
+    return matrix_get_axis(m_M, rtm::axis4::y);
 }
 void Matrix4x4::Up(const Vector3& v) noexcept
 {
-    _21 = v.x;
-    _22 = v.y;
-    _23 = v.z;
+    m_M = matrix_set_axis(m_M, v, rtm::axis4::y);
 }
 
 Vector3 Matrix4x4::Down() const noexcept
 {
-    return Vector3(-_21, -_22, -_23);
+    return -Up();
 }
 void Matrix4x4::Down(const Vector3& v) noexcept
 {
-    _21 = -v.x;
-    _22 = -v.y;
-    _23 = -v.z;
+    m_M = matrix_set_axis(m_M, -v, rtm::axis4::y);
 }
 
 Vector3 Matrix4x4::Right() const noexcept
 {
-    return Vector3(_11, _12, _13);
+    return matrix_get_axis(m_M, rtm::axis4::x);
 }
 void Matrix4x4::Right(const Vector3& v) noexcept
 {
-    _11 = v.x;
-    _12 = v.y;
-    _13 = v.z;
+    m_M = matrix_set_axis(m_M, v, rtm::axis4::x);
 }
 
 Vector3 Matrix4x4::Left() const noexcept
 {
-    return Vector3(-_11, -_12, -_13);
+    return -Right();
 }
 void Matrix4x4::Left(const Vector3& v) noexcept
 {
-    _11 = -v.x;
-    _12 = -v.y;
-    _13 = -v.z;
+    m_M = matrix_set_axis(m_M, -v, rtm::axis4::x);
 }
 
 Vector3 Matrix4x4::Forward() const noexcept
 {
-    return Vector3(-_31, -_32, -_33);
+    return matrix_get_axis(m_M, rtm::axis4::z);
 }
 void Matrix4x4::Forward(const Vector3& v) noexcept
 {
-    _31 = -v.x;
-    _32 = -v.y;
-    _33 = -v.z;
+    m_M = matrix_set_axis(m_M, v, rtm::axis4::z);
 }
 
 Vector3 Matrix4x4::Backward() const noexcept
 {
-    return Vector3(_31, _32, _33);
+    return -Forward();
 }
 void Matrix4x4::Backward(const Vector3& v) noexcept
 {
-    _31 = v.x;
-    _32 = v.y;
-    _33 = v.z;
+    m_M = matrix_set_axis(m_M, -v, rtm::axis4::z);
 }
 
 Vector3 Matrix4x4::Translation() const noexcept
 {
-    return Vector3(_41, _42, _43);
+    return matrix_get_axis(m_M, rtm::axis4::w);
 }
 void Matrix4x4::Translation(const Vector3& v) noexcept
 {
-    _41 = v.x;
-    _42 = v.y;
-    _43 = v.z;
+    m_M = matrix_set_axis(m_M, static_cast<Vector4::SIMDValueType>(v.AsPoint()), rtm::axis4::w);
 }
 
-inline Matrix4x4 Matrix4x4::CreateTranslation(const Vector3& position) noexcept
+Matrix4x4 Matrix4x4::CreateTranslation(const Vector3& position) noexcept
 {
-    return rtm::matrix_from_translation(position);
+    return rtm::matrix_from_translation(static_cast<Vector4::SIMDValueType>(position.AsPoint()));
 }
 
-inline Matrix4x4 Matrix4x4::CreateTranslation(float x, float y, float z) noexcept
+Matrix4x4 Matrix4x4::CreateTranslation(float x, float y, float z) noexcept
 {
-    return rtm::matrix_from_translation(vector_set(x, y, z));
+    return rtm::matrix_from_translation(rtm::vector_set(x, y, z, 1.0f));
 }
 
 Matrix4x4 Matrix4x4::CreatePerspectiveFieldOfViewLH(float fov, float aspectRatio, float nearPlane, float farPlane) noexcept

--- a/src/Math/Matrix4x4.h
+++ b/src/Math/Matrix4x4.h
@@ -130,8 +130,8 @@ public:
 
     static Matrix4x4 CreateFromAxisAngle(const Vector3& axis, float angle) noexcept;
 
-    static Matrix4x4 CreatePerspectiveFieldOfView(float fov, float aspectRatio, float nearPlane, float farPlane) noexcept;
-    static Matrix4x4 CreatePerspective(float width, float height, float nearPlane, float farPlane) noexcept;
+    static Matrix4x4 CreatePerspectiveFieldOfViewLH(float fov, float aspectRatio, float nearPlane, float farPlane) noexcept;
+    static Matrix4x4 CreatePerspectiveLH(float width, float height, float nearPlane, float farPlane) noexcept;
     static Matrix4x4 CreatePerspectiveOffCenter(float left, float right, float bottom, float top, float nearPlane, float farPlane) noexcept;
     static Matrix4x4 CreateOrthographic(float width, float height, float zNearPlane, float zFarPlane) noexcept;
     static Matrix4x4 CreateOrthographicOffCenter(float left, float right, float bottom, float top, float zNearPlane, float zFarPlane) noexcept;

--- a/src/Math/Matrix4x4.h
+++ b/src/Math/Matrix4x4.h
@@ -41,7 +41,7 @@ public:
 
     // clang-format off
     Matrix4x4() noexcept = default;
-    constexpr Matrix4x4(
+    Matrix4x4(
         float m00, float m01, float m02, float m03,
         float m10, float m11, float m12, float m13,
         float m20, float m21, float m22, float m23,

--- a/src/Math/Matrix4x4.h
+++ b/src/Math/Matrix4x4.h
@@ -6,7 +6,10 @@
 
 #include "Math/Defines.h"
 
+#include "rtm/vector4f.h"
+#include "rtm/matrix3x4f.h"
 #include "rtm/matrix4x4f.h"
+#include "rtm/impl/matrix_common.h"
 
 namespace gore
 {
@@ -20,22 +23,6 @@ ENGINE_STRUCT(Quaternion);
 ENGINE_STRUCT(Matrix4x4)
 {
 public:
-    // This is exactly how XMFLOAT4X4 declares its members
-    // Yes its constructor names parameters starting from "m00", which is different
-    // Since I'm simply copying calculations from SimpleMath.h (after removing its dependencies to types in DirectXMath)
-    // I'm keeping it this way
-    union
-    {
-        struct
-        {
-            float _11, _12, _13, _14;
-            float _21, _22, _23, _24;
-            float _31, _32, _33, _34;
-            float _41, _42, _43, _44;
-        };
-        float m[4][4];
-    };
-
     friend ENGINE_API_FUNC(std::ostream&, operator<<, std::ostream & os, const Matrix4x4& m) noexcept;
 
 public:
@@ -48,6 +35,8 @@ public:
     MATHF_MATRIX_COMPARISON_OPERATOR_DECLARATIONS(Matrix4x4);
     MATHF_MATRIX_COMPOUND_ASSIGNMENT_OPERATOR_DECLARATIONS(Matrix4x4);
 
+    SIMDValueType m_M;
+
     Matrix4x4(rtm::matrix3x4f && F) noexcept;
 
     // clang-format off
@@ -57,10 +46,11 @@ public:
         float m10, float m11, float m12, float m13,
         float m20, float m21, float m22, float m23,
         float m30, float m31, float m32, float m33) noexcept :
-        _11(m00), _12(m01), _13(m02), _14(m03),
-        _21(m10), _22(m11), _23(m12), _24(m13),
-        _31(m20), _32(m21), _33(m22), _34(m23),
-        _41(m30), _42(m31), _43(m32), _44(m33)
+        m_M(rtm::matrix_set(
+            rtm::vector_set(m00, m01, m02, m03),
+            rtm::vector_set(m10, m11, m12, m13),
+            rtm::vector_set(m20, m21, m22, m23),
+            rtm::vector_set(m30, m31, m32, m33)))
     {
     }
     // clang-format on

--- a/src/Math/Vector3.cpp
+++ b/src/Math/Vector3.cpp
@@ -1,5 +1,7 @@
 #include "Vector3.h"
 
+#include "Vector4.h"
+
 #include "rtm/vector4f.h"
 
 namespace gore
@@ -23,6 +25,16 @@ Vector3::Vector3(SIMDValueType F) noexcept :
     z()
 {
     vector_store(F, reinterpret_cast<float*>(this));
+}
+
+Vector4 Vector3::AsPoint() const noexcept
+{
+    return Vector4(x, y, z, 1.0f);
+}
+
+Vector4 Vector3::AsVector() const noexcept
+{
+    return Vector4(x, y, z, 0.0f);
 }
 
 } // namespace gore

--- a/src/Math/Vector3.h
+++ b/src/Math/Vector3.h
@@ -68,6 +68,9 @@ public:
     void Clamp(const Vector3& vmin, const Vector3& vmax) noexcept;
     void Clamp(const Vector3& vmin, const Vector3& vmax, Vector3& result) const noexcept;
 
+    Vector4 AsPoint() const noexcept;
+    Vector4 AsVector() const noexcept;
+
     // Static functions
     static float Distance(const Vector3& v1, const Vector3& v2) noexcept;
     static float DistanceSquared(const Vector3& v1, const Vector3& v2) noexcept;

--- a/src/Math/Vector4.cpp
+++ b/src/Math/Vector4.cpp
@@ -1,11 +1,20 @@
 #include "Vector4.h"
 
+#include "rtm/vector4f.h"
+
 namespace gore
 {
+
+using namespace rtm;
 
 std::ostream& operator<<(std::ostream& os, const Vector4& v) noexcept
 {
     return os << "Vector4(" << v.x << ", " << v.y << ", " << v.z << ", " << v.w << ")";
+}
+
+Vector4::operator SIMDValueType() const noexcept
+{
+    return vector_load((reinterpret_cast<const float*>(this)));
 }
 
 } // namespace gore


### PR DESCRIPTION
- Call `Matrix4x4::CreatePerspectiveFieldOfViewLH` or `Matrix4x4::CreatePerspectiveLH`
- Matrix4x4 now uses SIMD types directly

Other changes:
- Vector3 asPoint/asVector conversion to Vector4
- Vector4's conversion to SIMD types