### PR TITLE
Associate camera aspect ratio with window

### DIFF
--- a/sample/Scripts/TestComponent.cpp
+++ b/sample/Scripts/TestComponent.cpp
@@ -28,5 +28,5 @@ void TestComponent::Update()
 
     transform->RotateAroundAxis(gore::Vector3::Up, deltaTime);
 
-    LOG_STREAM(DEBUG) << "TestComponent position:" << transform->GetLocalPosition() << " Quaternion: " << transform->GetLocalRotation() << std::endl;
+    // LOG_STREAM(DEBUG) << "TestComponent position:" << transform->GetLocalPosition() << " Quaternion: " << transform->GetLocalRotation() << std::endl;
 }

--- a/src/Core/Log.h
+++ b/src/Core/Log.h
@@ -16,11 +16,6 @@
         ::gore::Logger::Default().Log(::gore::LogLevel::LEVEL, __FILE__, __LINE__, __VA_ARGS__); \
     } while (false)
 
-// windows.h, sigh...
-#ifdef ERROR
-#undef ERROR
-#endif
-
 namespace gore
 {
 

--- a/src/Graphics/Utils.h
+++ b/src/Graphics/Utils.h
@@ -2,10 +2,6 @@
 
 #include <string>
 
-#ifdef None // X11 defines this
-    #undef None
-#endif
-
 namespace gore::gfx
 {
 

--- a/src/Graphics/Vulkan/VulkanIncludes.h
+++ b/src/Graphics/Vulkan/VulkanIncludes.h
@@ -38,10 +38,6 @@
 #endif
 #include <vk_mem_alloc.h>
 
-#ifdef ERROR
-    #undef ERROR
-#endif
-
 #if !ENGINE_DEBUG
 
     #define VK_CHECK_RESULT(x) \

--- a/src/Math/Matrix4x4.cpp
+++ b/src/Math/Matrix4x4.cpp
@@ -179,15 +179,15 @@ Matrix4x4 Matrix4x4::CreatePerspectiveFieldOfViewLH(float fov, float aspectRatio
         rtm::vector_set(0.0f, 0.0f, fRange, 1.0f),
         rtm::vector_set(0.0f, 0.0f, -fRange * nearPlane, 0.0f))));
 }
-Matrix4x4 Matrix4x4::CreateOrthographicLH(float width, float height, float zNearPlane, float zFarPlane) noexcept
+Matrix4x4 Matrix4x4::CreateOrthographicLH(float width, float height, float nearPlane, float farPlane) noexcept
 {
-    float fRange = 1.0f / (zFarPlane - zNearPlane);
+    float fRange = 1.0f / (farPlane - nearPlane);
 
     return static_cast<Matrix4x4>(rtm::matrix_set(
         rtm::vector_set(2.0f / width, 0.0f, 0.0f, 0.0f),
         rtm::vector_set(0.0f, 2.0f / height, 0.0f, 0.0f),
         rtm::vector_set(0.0f, 0.0f, -fRange, 0.0f),
-        rtm::vector_set(0.0f, 0.0f, fRange * zFarPlane, 1.0f)));
+        rtm::vector_set(0.0f, 0.0f, fRange * farPlane, 1.0f)));
 }
 
 } // namespace gore

--- a/src/Math/Matrix4x4.cpp
+++ b/src/Math/Matrix4x4.cpp
@@ -186,8 +186,8 @@ Matrix4x4 Matrix4x4::CreateOrthographicLH(float width, float height, float zNear
     return static_cast<Matrix4x4>(rtm::matrix_set(
         rtm::vector_set(2.0f / width, 0.0f, 0.0f, 0.0f),
         rtm::vector_set(0.0f, 2.0f / height, 0.0f, 0.0f),
-        rtm::vector_set(0.0f, 0.0f, fRange, 0.0f),
-        rtm::vector_set(0.0f, 0.0f, -fRange * zNearPlane, 1.0f)));
+        rtm::vector_set(0.0f, 0.0f, -fRange, 0.0f),
+        rtm::vector_set(0.0f, 0.0f, fRange * zFarPlane, 1.0f)));
 }
 
 } // namespace gore

--- a/src/Math/Matrix4x4.h
+++ b/src/Math/Matrix4x4.h
@@ -123,7 +123,7 @@ public:
     // Projection matrices
     [[nodiscard]] static Matrix4x4 CreatePerspectiveFieldOfViewLH(float fov, float aspectRatio, float nearPlane, float farPlane) noexcept;
 //    [[nodiscard]] static Matrix4x4 CreatePerspectiveOffCenterLH(float left, float right, float bottom, float top, float nearPlane, float farPlane) noexcept;
-    [[nodiscard]] static Matrix4x4 CreateOrthographicLH(float width, float height, float zNearPlane, float zFarPlane) noexcept;
+    [[nodiscard]] static Matrix4x4 CreateOrthographicLH(float width, float height, float nearPlane, float farPlane) noexcept;
 //    [[nodiscard]] static Matrix4x4 CreateOrthographicOffCenterLH(float left, float right, float bottom, float top, float zNearPlane, float zFarPlane) noexcept;
 
     [[nodiscard]] static Matrix4x4 CreateLookAt(const Vector3& position, const Vector3& target, const Vector3& up) noexcept;

--- a/src/Object/Camera.cpp
+++ b/src/Object/Camera.cpp
@@ -2,6 +2,8 @@
 
 #include "Object/GameObject.h"
 #include "Math/Matrix4x4.h"
+#include "Windowing/Window.h"
+#include "Core/App.h"
 
 namespace gore
 {
@@ -12,10 +14,16 @@ void Camera::Start()
 
 void Camera::Update()
 {
+    if (m_AspectRatioMode == AspectRatioMode::FollowWindow)
+    {
+        ResetAspectRatio();
+    }
 }
 
 Camera::Camera(gore::GameObject* gameObject) noexcept :
     Component(gameObject),
+    m_Window(App::Get()->GetWindow()),
+    m_AspectRatioMode(AspectRatioMode::FollowWindow),
     m_ProjectionType(DefaultProjectionType),
     m_AspectRatio(DefaultAspectRatio),
     m_PerspectiveFOV(DefaultPerspectiveFOV),
@@ -42,6 +50,20 @@ Matrix4x4 Camera::GetViewMatrix() const
 Matrix4x4 Camera::GetViewProjectionMatrix() const
 {
     return GetViewMatrix() * GetProjectionMatrix();
+}
+
+void Camera::SetAspectRatio(float aspectRatio)
+{
+    m_AspectRatio = aspectRatio;
+    m_AspectRatioMode = AspectRatioMode::Custom;
+}
+
+void Camera::ResetAspectRatio()
+{
+    int width, height;
+    m_Window->GetSize(&width, &height);
+    m_AspectRatio = static_cast<float>(width) / static_cast<float>(height);
+    m_AspectRatioMode = AspectRatioMode::FollowWindow;
 }
 
 // constants

--- a/src/Object/Camera.cpp
+++ b/src/Object/Camera.cpp
@@ -18,19 +18,19 @@ Camera::Camera(gore::GameObject* gameObject) noexcept :
     Component(gameObject),
     m_ProjectionType(DefaultProjectionType),
     m_PerspectiveFOV(DefaultPerspectiveFOV),
-    m_PerspectiveAspectRatio(DefaultPerspectiveAspectRatio),
+    m_AspectRatio(DefaultAspectRatio),
     m_OrthographicViewWidth(DefaultOrthographicViewWidth),
     m_OrthographicViewHeight(DefaultOrthographicViewHeight),
-    m_ZMin(DefaultZMin),
-    m_ZMax(DefaultZMax)
+    m_Near(DefaultZMin),
+    m_Far(DefaultZMax)
 {
 }
 
 Matrix4x4 Camera::GetProjectionMatrix() const
 {
     return m_ProjectionType == ProjectionType::Perspective ?
-               Matrix4x4::CreatePerspectiveFieldOfViewLH(m_PerspectiveFOV, m_PerspectiveAspectRatio, m_ZMin, m_ZMax) :
-               Matrix4x4::CreateOrthographicLH(m_OrthographicViewWidth, m_OrthographicViewHeight, m_ZMin, m_ZMax);
+               Matrix4x4::CreatePerspectiveFieldOfViewLH(m_PerspectiveFOV, m_AspectRatio, m_Near, m_Far) :
+               Matrix4x4::CreateOrthographicLH(m_OrthographicViewWidth, m_OrthographicViewHeight, m_Near, m_Far);
 }
 
 Matrix4x4 Camera::GetViewMatrix() const
@@ -48,7 +48,7 @@ Matrix4x4 Camera::GetViewProjectionMatrix() const
 // constants
 const Camera::ProjectionType Camera::DefaultProjectionType = Camera::ProjectionType::Perspective;
 const float Camera::DefaultPerspectiveFOV                  = math::constants::PI_3;
-const float Camera::DefaultPerspectiveAspectRatio          = 16.0f / 9.0f;
+const float Camera::DefaultAspectRatio                     = 16.0f / 9.0f;
 const float Camera::DefaultOrthographicViewWidth           = 16.0f;
 const float Camera::DefaultOrthographicViewHeight          = 9.0f;
 const float Camera::DefaultZMin                            = 0.1f;

--- a/src/Object/Camera.cpp
+++ b/src/Object/Camera.cpp
@@ -17,12 +17,11 @@ void Camera::Update()
 Camera::Camera(gore::GameObject* gameObject) noexcept :
     Component(gameObject),
     m_ProjectionType(DefaultProjectionType),
-    m_PerspectiveFOV(DefaultPerspectiveFOV),
     m_AspectRatio(DefaultAspectRatio),
-    m_OrthographicViewWidth(DefaultOrthographicViewWidth),
-    m_OrthographicViewHeight(DefaultOrthographicViewHeight),
-    m_Near(DefaultZMin),
-    m_Far(DefaultZMax)
+    m_PerspectiveFOV(DefaultPerspectiveFOV),
+    m_OrthographicSize(DefaultOrthographicSize),
+    m_Near(DefaultNear),
+    m_Far(DefaultFar)
 {
 }
 
@@ -30,7 +29,7 @@ Matrix4x4 Camera::GetProjectionMatrix() const
 {
     return m_ProjectionType == ProjectionType::Perspective ?
                Matrix4x4::CreatePerspectiveFieldOfViewLH(m_PerspectiveFOV, m_AspectRatio, m_Near, m_Far) :
-               Matrix4x4::CreateOrthographicLH(m_OrthographicViewWidth, m_OrthographicViewHeight, m_Near, m_Far);
+               Matrix4x4::CreateOrthographicLH(DefaultOrthographicSize * DefaultAspectRatio, DefaultOrthographicSize, m_Near, m_Far);
 }
 
 Matrix4x4 Camera::GetViewMatrix() const
@@ -47,11 +46,10 @@ Matrix4x4 Camera::GetViewProjectionMatrix() const
 
 // constants
 const Camera::ProjectionType Camera::DefaultProjectionType = Camera::ProjectionType::Perspective;
-const float Camera::DefaultPerspectiveFOV                  = math::constants::PI_3;
 const float Camera::DefaultAspectRatio                     = 16.0f / 9.0f;
-const float Camera::DefaultOrthographicViewWidth           = 16.0f;
-const float Camera::DefaultOrthographicViewHeight          = 9.0f;
-const float Camera::DefaultZMin                            = 0.1f;
-const float Camera::DefaultZMax                            = 1000.0f;
+const float Camera::DefaultPerspectiveFOV                  = math::constants::PI_3;
+const float Camera::DefaultOrthographicSize                = 1.0f;
+const float Camera::DefaultNear                            = 0.1f;
+const float Camera::DefaultFar                             = 1000.0f;
 
 } // namespace gore

--- a/src/Object/Camera.cpp
+++ b/src/Object/Camera.cpp
@@ -29,7 +29,7 @@ Matrix4x4 Camera::GetProjectionMatrix() const
 {
     return m_ProjectionType == ProjectionType::Perspective ?
                Matrix4x4::CreatePerspectiveFieldOfViewLH(m_PerspectiveFOV, m_AspectRatio, m_Near, m_Far) :
-               Matrix4x4::CreateOrthographicLH(DefaultOrthographicSize * DefaultAspectRatio, DefaultOrthographicSize, m_Near, m_Far);
+               Matrix4x4::CreateOrthographicLH(m_OrthographicSize * m_AspectRatio, m_OrthographicSize, m_Near, m_Far);
 }
 
 Matrix4x4 Camera::GetViewMatrix() const

--- a/src/Object/Camera.h
+++ b/src/Object/Camera.h
@@ -28,10 +28,8 @@ public:
     [[nodiscard]] float GetPerspectiveFOV() const { return m_PerspectiveFOV; }
     void SetFOV(float fov) { m_PerspectiveFOV = fov; }
 
-    [[nodiscard]] float GetOrthographicWidth() const { return m_OrthographicViewWidth; }
-    void SetOrthographicWidth(float width) { m_OrthographicViewWidth = width; }
-    [[nodiscard]] float GetOrthographicHeight() const { return m_OrthographicViewHeight; }
-    void SetOrthographicHeight(float height) { m_OrthographicViewHeight = height; }
+    [[nodiscard]] float GetOrthographicSize() const { return m_OrthographicSize; }
+    void SetOrthographicSize(float size) { m_OrthographicSize = size; }
 
     [[nodiscard]] float GetNear() const { return m_Near; }
     void SetNear(float near) { m_Near = near; }
@@ -56,19 +54,17 @@ public:
     void Update() override;
 
 public:
-    static const float DefaultPerspectiveFOV;
     static const float DefaultAspectRatio;
-    static const float DefaultOrthographicViewWidth;
-    static const float DefaultOrthographicViewHeight;
-    static const float DefaultZMin;
-    static const float DefaultZMax;
+    static const float DefaultPerspectiveFOV;
+    static const float DefaultOrthographicSize;
+    static const float DefaultNear;
+    static const float DefaultFar;
     static const ProjectionType DefaultProjectionType;
 
 private:
-    float m_PerspectiveFOV;
     float m_AspectRatio;
-    float m_OrthographicViewWidth;
-    float m_OrthographicViewHeight;
+    float m_PerspectiveFOV;
+    float m_OrthographicSize;
     float m_Near;
     float m_Far;
     ProjectionType m_ProjectionType;

--- a/src/Object/Camera.h
+++ b/src/Object/Camera.h
@@ -7,6 +7,7 @@ namespace gore
 {
 
 struct Matrix4x4;
+class Window;
 
 ENGINE_CLASS(Camera) final : public Component
 {
@@ -25,6 +26,9 @@ public:
 
     // clang-format off
     // properties
+    [[nodiscard]] Window* GetWindow() const { return m_Window; }
+    void SetWindow(Window* window) { m_Window = window; }
+
     [[nodiscard]] float GetPerspectiveFOV() const { return m_PerspectiveFOV; }
     void SetFOV(float fov) { m_PerspectiveFOV = fov; }
 
@@ -40,14 +44,15 @@ public:
     void SetProjectionType(ProjectionType projectionType) { m_ProjectionType = projectionType; }
 
     [[nodiscard]] float GetPerspectiveAspectRatio() const { return m_AspectRatio; }
-    void SetAspectRatio(float aspectRatio) { m_AspectRatio = aspectRatio; }
+    void SetAspectRatio(float aspectRatio);
+    void ResetAspectRatio();
     // clang-format on
 
 public:
     NON_COPYABLE(Camera);
 
     Camera() = delete;
-    explicit Camera(GameObject * gameObject) noexcept;
+    explicit Camera(GameObject* gameObject) noexcept;
     ~Camera() override = default;
 
     void Start() override;
@@ -62,6 +67,17 @@ public:
     static const ProjectionType DefaultProjectionType;
 
 private:
+    enum class AspectRatioMode
+    {
+        FollowWindow,
+        Custom
+    };
+
+private:
+    Window* m_Window;
+
+    AspectRatioMode m_AspectRatioMode;
+
     float m_AspectRatio;
     float m_PerspectiveFOV;
     float m_OrthographicSize;

--- a/src/Object/Camera.h
+++ b/src/Object/Camera.h
@@ -27,22 +27,22 @@ public:
     // properties
     [[nodiscard]] float GetPerspectiveFOV() const { return m_PerspectiveFOV; }
     void SetFOV(float fov) { m_PerspectiveFOV = fov; }
-    [[nodiscard]] float GetPerspectiveAspectRatio() const { return m_PerspectiveAspectRatio; }
-    void SetAspectRatio(float aspectRatio) { m_PerspectiveAspectRatio = aspectRatio; }
 
     [[nodiscard]] float GetOrthographicWidth() const { return m_OrthographicViewWidth; }
     void SetOrthographicWidth(float width) { m_OrthographicViewWidth = width; }
     [[nodiscard]] float GetOrthographicHeight() const { return m_OrthographicViewHeight; }
     void SetOrthographicHeight(float height) { m_OrthographicViewHeight = height; }
 
-    // okay lets avoid using near/far because of macros defined in windows.h
-    [[nodiscard]] float GetZMin() const { return m_ZMin; }
-    void SetNear(float zMin) { m_ZMin = zMin; }
-    [[nodiscard]] float GetZMax() const { return m_ZMax; }
-    void SetZMax(float zMax) { m_ZMax = zMax; }
+    [[nodiscard]] float GetNear() const { return m_Near; }
+    void SetNear(float near) { m_Near = near; }
+    [[nodiscard]] float GetFar() const { return m_Far; }
+    void SetFar(float far) { m_Far = far; }
 
     [[nodiscard]] ProjectionType GetProjectionType() const { return m_ProjectionType; }
     void SetProjectionType(ProjectionType projectionType) { m_ProjectionType = projectionType; }
+
+    [[nodiscard]] float GetPerspectiveAspectRatio() const { return m_AspectRatio; }
+    void SetAspectRatio(float aspectRatio) { m_AspectRatio = aspectRatio; }
     // clang-format on
 
 public:
@@ -57,7 +57,7 @@ public:
 
 public:
     static const float DefaultPerspectiveFOV;
-    static const float DefaultPerspectiveAspectRatio;
+    static const float DefaultAspectRatio;
     static const float DefaultOrthographicViewWidth;
     static const float DefaultOrthographicViewHeight;
     static const float DefaultZMin;
@@ -66,11 +66,11 @@ public:
 
 private:
     float m_PerspectiveFOV;
-    float m_PerspectiveAspectRatio;
+    float m_AspectRatio;
     float m_OrthographicViewWidth;
     float m_OrthographicViewHeight;
-    float m_ZMin;
-    float m_ZMax;
+    float m_Near;
+    float m_Far;
     ProjectionType m_ProjectionType;
 };
 

--- a/src/Prefix.h
+++ b/src/Prefix.h
@@ -52,3 +52,40 @@
 #include <cstdint>
 
 #include "Utilities/Defines.h"
+
+// some pre-includes and undefs to prevent future conflicts
+#if PLATFORM_WIN
+    #define WIN32_LEAN_AND_MEAN
+    #define NOMINMAX
+    #include <Windows.h>
+#elif PLATFORM_LINUX
+    #include <X11/Xlib.h>
+#elif PLATFORM_MACOS
+
+#endif
+
+// windows
+#ifdef ERROR
+    #undef ERROR
+#endif
+
+#ifdef near
+    #undef near
+#endif
+
+#ifdef far
+    #undef far
+#endif
+
+#ifdef min
+    #undef min
+#endif
+
+#ifdef max
+    #undef max
+#endif
+
+// x11
+#ifdef None
+    #undef None
+#endif

--- a/src/Rendering/RenderSystem.cpp
+++ b/src/Rendering/RenderSystem.cpp
@@ -25,10 +25,6 @@
 #include <algorithm>
 #include <filesystem>
 
-#ifdef ERROR
-    #undef ERROR
-#endif
-
 namespace gore
 {
 


### PR DESCRIPTION
Several changes:

* Move all macro conflict undefs into `Prefix.h`. This makes it mandatory to include `Prefix.h` at the very beginning of all `.cpp` source files.
* Fixed orthographic reverse Z matrix in #29. The perspective reverse Z matrix in that PR is correct.
* Associate camera aspect ratio with window.
  * Introduced an aspect ratio mode which allows the user to set custom ratio, as well as a Reset function.
* Some symbol rename for consistency.

Check `test_camera` branch for testing.