### PR TITLE
Pin vcpkg version to one prior to vulkan sdk change

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "gore",
   "version": "0.0.1",
+  "builtin-baseline": "209485d769dfa674872dacfef5b2755a77d5f2fe",
   "dependencies": [
     "assimp",
     "cgltf",


### PR DESCRIPTION
See PR 35479 of vcpkg. I'm not linking it here to prevent mentioning on their side.

This vcpkg changes the way port `vulkan` is installed. Before this change, the `vulkan` is a stub port which only checks if Vulkan SDK is locally installed when installing from vcpkg. After the PR, vcpkg will actually build Vulkan SDK including loaders, tools, and so on from source.

This change brings two problems for us at this point:
1. The `Ubuntu Clang` setup will fail. It seems that in [vcpkg CI](https://dev.azure.com/vcpkg/public/_build/results?buildId=97639&view=logs&jobId=f79cfdd7-47a8-597f-8f57-dc3e21a8f2ad&j=f79cfdd7-47a8-597f-8f57-dc3e21a8f2ad&t=da63cf11-1f12-503b-6d64-3b2fb713c172) they only check for GCC but not for Clang.
2. The vcpkg change didn't bring MoltenVK with it, for whatever reason. Since we will copy MoltenVK binary to our app bundle in macOS build, this causes `macOS` setup to fail.