### PR TITLE
Input System

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set(COMMON_SOURCE_FOLDERS
         "Rendering"
         "Scene"
         "Object"
+        "Input"
         "Utilities"
         "Test"
 )

--- a/src/Core/App.cpp
+++ b/src/Core/App.cpp
@@ -10,6 +10,7 @@
 #include "Rendering/RenderSystem.h"
 #include "Windowing/Window.h"
 #include "Scene/Scene.h"
+#include "Input/GLFW/GLFWInputSystem.h"
 
 namespace gore
 {
@@ -20,6 +21,7 @@ App::App(int argc, char** argv) :
     m_Args(argv + 1, argv + argc),
     m_ExecutablePath(argv[0]),
     m_TimeSystem(nullptr),
+    m_InputSystem(nullptr),
     m_RenderSystem(nullptr),
     m_Window(nullptr)
 {
@@ -49,6 +51,10 @@ int App::Run(int width, int height, const char* title)
     m_Window = new Window(this, width, height);
     m_Window->SetTitle(title);
 
+    // TODO: Choose backend
+    m_InputSystem = new GLFWInputSystem(this);
+    m_InputSystem->Initialize();
+
     m_RenderSystem = new RenderSystem(this);
     m_RenderSystem->Initialize();
 
@@ -60,6 +66,7 @@ int App::Run(int width, int height, const char* title)
     while (!m_Window->ShouldClose())
     {
         m_TimeSystem->Update();
+        m_InputSystem->Update();
 
         Update();
 
@@ -75,10 +82,11 @@ int App::Run(int width, int height, const char* title)
     Shutdown();
 
     m_RenderSystem->Shutdown();
-
+    m_InputSystem->Shutdown();
 
     delete m_TimeSystem;
     delete m_RenderSystem;
+    delete m_InputSystem;
 
     delete m_Window;
 

--- a/src/Core/App.h
+++ b/src/Core/App.h
@@ -14,6 +14,7 @@ namespace gore
 class Window;
 
 class Time;
+class InputSystem;
 class RenderSystem;
 
 ENGINE_CLASS(App)
@@ -51,6 +52,7 @@ private:
 
 private:
     Time* m_TimeSystem;
+    InputSystem* m_InputSystem;
     RenderSystem* m_RenderSystem;
 
     Window* m_Window;

--- a/src/Input/GLFW/GLFWInputDevice.cpp
+++ b/src/Input/GLFW/GLFWInputDevice.cpp
@@ -84,9 +84,6 @@ void GLFWMouse::Update()
     m_Movements[static_cast<int>(MouseMovementCode::ScrollX)].state     = static_cast<float>(m_ScrollX);
     m_Movements[static_cast<int>(MouseMovementCode::ScrollY)].state     = static_cast<float>(m_ScrollY);
 
-    m_ScrollX = 0.0;
-    m_ScrollY = 0.0;
-
     UpdateAllActions();
 }
 

--- a/src/Input/GLFW/GLFWInputDevice.cpp
+++ b/src/Input/GLFW/GLFWInputDevice.cpp
@@ -67,7 +67,7 @@ void GLFWMouse::Update()
     m_Movements[static_cast<int>(MouseMovementCode::Y)].state = static_cast<float>(y);
 }
 
-void GLFWMouse::SetCursorShow(bool show)
+void GLFWMouse::SetCursorShow(bool show) const
 {
     glfwSetInputMode(m_Window->Get(), GLFW_CURSOR, show ? GLFW_CURSOR_NORMAL : GLFW_CURSOR_DISABLED);
 }

--- a/src/Input/GLFW/GLFWInputDevice.cpp
+++ b/src/Input/GLFW/GLFWInputDevice.cpp
@@ -1,0 +1,295 @@
+#include "Prefix.h"
+
+#include "GLFWInputDevice.h"
+#include "Windowing/Window.h"
+
+#include <GLFW/glfw3.h>
+
+namespace gore
+{
+
+static int GetGLFWKeyCode(KeyCode keyCode);
+
+GLFWKeyboard::GLFWKeyboard(Window* window) :
+    Keyboard(),
+    m_Window(window)
+{
+}
+
+GLFWKeyboard::~GLFWKeyboard()
+{
+}
+
+void GLFWKeyboard::Update()
+{
+    for (int i = 0; i < static_cast<int>(KeyCode::Count); ++i)
+    {
+        const KeyCode keyCode = static_cast<KeyCode>(i);
+        const int glfwKeyCode = GetGLFWKeyCode(keyCode);
+
+        const bool state = glfwGetKey(m_Window->Get(), glfwKeyCode) == GLFW_PRESS;
+        DigitalState& digitalState = m_Keys[i];
+
+        digitalState.lastState = digitalState.state;
+        digitalState.state = state;
+    }
+}
+
+GLFWMouse::GLFWMouse(Window* window) :
+    Mouse(),
+    m_Window(window)
+{
+}
+
+GLFWMouse::~GLFWMouse()
+{
+}
+
+void GLFWMouse::Update()
+{
+    for (int i = 0; i < static_cast<int>(MouseButtonCode::Count); ++i)
+    {
+        const MouseButtonCode buttonCode = static_cast<MouseButtonCode>(i);
+
+        const bool state = glfwGetMouseButton(m_Window->Get(), i) == GLFW_PRESS;
+        DigitalState& digitalState = m_Buttons[i];
+
+        digitalState.lastState = digitalState.state;
+        digitalState.state = state;
+    }
+
+    double x, y;
+    glfwGetCursorPos(m_Window->Get(), &x, &y);
+
+    m_Movements[static_cast<int>(MouseMovementCode::X)].lastState = m_Movements[static_cast<int>(MouseMovementCode::X)].state;
+    m_Movements[static_cast<int>(MouseMovementCode::Y)].lastState = m_Movements[static_cast<int>(MouseMovementCode::Y)].state;
+    m_Movements[static_cast<int>(MouseMovementCode::X)].state = static_cast<float>(x);
+    m_Movements[static_cast<int>(MouseMovementCode::Y)].state = static_cast<float>(y);
+}
+
+void GLFWMouse::SetCursorShow(bool show)
+{
+    glfwSetInputMode(m_Window->Get(), GLFW_CURSOR, show ? GLFW_CURSOR_NORMAL : GLFW_CURSOR_DISABLED);
+}
+
+int GetGLFWKeyCode(KeyCode keyCode)
+{
+    switch (keyCode)
+    {
+        case KeyCode::Backspace:
+            return GLFW_KEY_BACKSPACE;
+        case KeyCode::Delete:
+            return GLFW_KEY_DELETE;
+        case KeyCode::Tab:
+            return GLFW_KEY_TAB;
+        case KeyCode::Return:
+            return GLFW_KEY_ENTER;
+        case KeyCode::Esc:
+            return GLFW_KEY_ESCAPE;
+        case KeyCode::Space:
+            return GLFW_KEY_SPACE;
+        case KeyCode::Keypad0:
+            return GLFW_KEY_KP_0;
+        case KeyCode::Keypad1:
+            return GLFW_KEY_KP_1;
+        case KeyCode::Keypad2:
+            return GLFW_KEY_KP_2;
+        case KeyCode::Keypad3:
+            return GLFW_KEY_KP_3;
+        case KeyCode::Keypad4:
+            return GLFW_KEY_KP_4;
+        case KeyCode::Keypad5:
+            return GLFW_KEY_KP_5;
+        case KeyCode::Keypad6:
+            return GLFW_KEY_KP_6;
+        case KeyCode::Keypad7:
+            return GLFW_KEY_KP_7;
+        case KeyCode::Keypad8:
+            return GLFW_KEY_KP_8;
+        case KeyCode::Keypad9:
+            return GLFW_KEY_KP_9;
+        case KeyCode::KeypadPeriod:
+            return GLFW_KEY_KP_DECIMAL;
+        case KeyCode::KeypadDivide:
+            return GLFW_KEY_KP_DIVIDE;
+        case KeyCode::KeypadMultiply:
+            return GLFW_KEY_KP_MULTIPLY;
+        case KeyCode::KeypadMinus:
+            return GLFW_KEY_KP_SUBTRACT;
+        case KeyCode::KeypadPlus:
+            return GLFW_KEY_KP_ADD;
+        case KeyCode::KeypadEnter:
+            return GLFW_KEY_KP_ENTER;
+        case KeyCode::Up:
+            return GLFW_KEY_UP;
+        case KeyCode::Down:
+            return GLFW_KEY_DOWN;
+        case KeyCode::Right:
+            return GLFW_KEY_RIGHT;
+        case KeyCode::Left:
+            return GLFW_KEY_LEFT;
+        case KeyCode::Insert:
+            return GLFW_KEY_INSERT;
+        case KeyCode::Home:
+            return GLFW_KEY_HOME;
+        case KeyCode::End:
+            return GLFW_KEY_END;
+        case KeyCode::PageUp:
+            return GLFW_KEY_PAGE_UP;
+        case KeyCode::PageDown:
+            return GLFW_KEY_PAGE_DOWN;
+        case KeyCode::F1:
+            return GLFW_KEY_F1;
+        case KeyCode::F2:
+            return GLFW_KEY_F2;
+        case KeyCode::F3:
+            return GLFW_KEY_F3;
+        case KeyCode::F4:
+            return GLFW_KEY_F4;
+        case KeyCode::F5:
+            return GLFW_KEY_F5;
+        case KeyCode::F6:
+            return GLFW_KEY_F6;
+        case KeyCode::F7:
+            return GLFW_KEY_F7;
+        case KeyCode::F8:
+            return GLFW_KEY_F8;
+        case KeyCode::F9:
+            return GLFW_KEY_F9;
+        case KeyCode::F10:
+            return GLFW_KEY_F10;
+        case KeyCode::F11:
+            return GLFW_KEY_F11;
+        case KeyCode::F12:
+            return GLFW_KEY_F12;
+        case KeyCode::F13:
+            return GLFW_KEY_F13;
+        case KeyCode::F14:
+            return GLFW_KEY_F14;
+        case KeyCode::F15:
+            return GLFW_KEY_F15;
+        case KeyCode::Number0:
+            return GLFW_KEY_0;
+        case KeyCode::Number1:
+            return GLFW_KEY_1;
+        case KeyCode::Number2:
+            return GLFW_KEY_2;
+        case KeyCode::Number3:
+            return GLFW_KEY_3;
+        case KeyCode::Number4:
+            return GLFW_KEY_4;
+        case KeyCode::Number5:
+            return GLFW_KEY_5;
+        case KeyCode::Number6:
+            return GLFW_KEY_6;
+        case KeyCode::Number7:
+            return GLFW_KEY_7;
+        case KeyCode::Number8:
+            return GLFW_KEY_8;
+        case KeyCode::Number9:
+            return GLFW_KEY_9;
+        case KeyCode::Quote:
+            return GLFW_KEY_APOSTROPHE;
+        case KeyCode::Comma:
+            return GLFW_KEY_COMMA;
+        case KeyCode::Minus:
+            return GLFW_KEY_MINUS;
+        case KeyCode::Period:
+            return GLFW_KEY_PERIOD;
+        case KeyCode::Slash:
+            return GLFW_KEY_SLASH;
+        case KeyCode::Semicolon:
+            return GLFW_KEY_SEMICOLON;
+        case KeyCode::Equal:
+            return GLFW_KEY_EQUAL;
+        case KeyCode::LeftBracket:
+            return GLFW_KEY_LEFT_BRACKET;
+        case KeyCode::Backslash:
+            return GLFW_KEY_BACKSLASH;
+        case KeyCode::RightBracket:
+            return GLFW_KEY_RIGHT_BRACKET;
+        case KeyCode::BackQuote:
+            return GLFW_KEY_GRAVE_ACCENT;
+        case KeyCode::A:
+            return GLFW_KEY_A;
+        case KeyCode::B:
+            return GLFW_KEY_B;
+        case KeyCode::C:
+            return GLFW_KEY_C;
+        case KeyCode::D:
+            return GLFW_KEY_D;
+        case KeyCode::E:
+            return GLFW_KEY_E;
+        case KeyCode::F:
+            return GLFW_KEY_F;
+        case KeyCode::G:
+            return GLFW_KEY_G;
+        case KeyCode::H:
+            return GLFW_KEY_H;
+        case KeyCode::I:
+            return GLFW_KEY_I;
+        case KeyCode::J:
+            return GLFW_KEY_J;
+        case KeyCode::K:
+            return GLFW_KEY_K;
+        case KeyCode::L:
+            return GLFW_KEY_L;
+        case KeyCode::M:
+            return GLFW_KEY_M;
+        case KeyCode::N:
+            return GLFW_KEY_N;
+        case KeyCode::O:
+            return GLFW_KEY_O;
+        case KeyCode::P:
+            return GLFW_KEY_P;
+        case KeyCode::Q:
+            return GLFW_KEY_Q;
+        case KeyCode::R:
+            return GLFW_KEY_R;
+        case KeyCode::S:
+            return GLFW_KEY_S;
+        case KeyCode::T:
+            return GLFW_KEY_T;
+        case KeyCode::U:
+            return GLFW_KEY_U;
+        case KeyCode::V:
+            return GLFW_KEY_V;
+        case KeyCode::W:
+            return GLFW_KEY_W;
+        case KeyCode::X:
+            return GLFW_KEY_X;
+        case KeyCode::Y:
+            return GLFW_KEY_Y;
+        case KeyCode::Z:
+            return GLFW_KEY_Z;
+        case KeyCode::NumLock:
+            return GLFW_KEY_NUM_LOCK;
+        case KeyCode::CapsLock:
+            return GLFW_KEY_CAPS_LOCK;
+        case KeyCode::ScrollLock:
+            return GLFW_KEY_SCROLL_LOCK;
+        case KeyCode::RightShift:
+            return GLFW_KEY_RIGHT_SHIFT;
+        case KeyCode::LeftShift:
+            return GLFW_KEY_LEFT_SHIFT;
+        case KeyCode::RightControl:
+            return GLFW_KEY_RIGHT_CONTROL;
+        case KeyCode::LeftControl:
+            return GLFW_KEY_LEFT_CONTROL;
+        case KeyCode::RightAlt:
+            return GLFW_KEY_RIGHT_ALT;
+        case KeyCode::LeftAlt:
+            return GLFW_KEY_LEFT_ALT;
+        case KeyCode::LeftWindows:
+            return GLFW_KEY_LEFT_SUPER;
+        case KeyCode::RightWindows:
+            return GLFW_KEY_RIGHT_SUPER;
+        case KeyCode::Menu:
+            return GLFW_KEY_MENU;
+        case KeyCode::ErrorKey:
+        default:
+            return GLFW_KEY_UNKNOWN;
+    }
+}
+
+}

--- a/src/Input/GLFW/GLFWInputDevice.h
+++ b/src/Input/GLFW/GLFWInputDevice.h
@@ -27,7 +27,7 @@ public:
 
     void Update() final;
 
-    void SetCursorShow(bool show) final;
+    void SetCursorShow(bool show) const final;
 
 private:
     Window* m_Window;

--- a/src/Input/GLFW/GLFWInputDevice.h
+++ b/src/Input/GLFW/GLFWInputDevice.h
@@ -2,6 +2,8 @@
 
 #include "Input/InputDevice.h"
 
+typedef struct GLFWwindow GLFWwindow;
+
 namespace gore
 {
 
@@ -31,6 +33,11 @@ public:
 
 private:
     Window* m_Window;
+
+    double m_ScrollX;
+    double m_ScrollY;
+
+    void ScrollCallback(GLFWwindow* window, double x, double y);
 };
 
 } // namespace gore

--- a/src/Input/GLFW/GLFWInputDevice.h
+++ b/src/Input/GLFW/GLFWInputDevice.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Input/InputDevice.h"
+
+namespace gore
+{
+
+class Window;
+
+class GLFWKeyboard final : public Keyboard
+{
+public:
+    explicit GLFWKeyboard(Window* window);
+    ~GLFWKeyboard() final;
+
+    void Update() final;
+
+private:
+    Window* m_Window;
+};
+
+class GLFWMouse final : public Mouse
+{
+public:
+    explicit GLFWMouse(Window* window);
+    ~GLFWMouse() final;
+
+    void Update() final;
+
+    void SetCursorShow(bool show) final;
+
+private:
+    Window* m_Window;
+};
+
+} // namespace gore

--- a/src/Input/GLFW/GLFWInputSystem.cpp
+++ b/src/Input/GLFW/GLFWInputSystem.cpp
@@ -4,6 +4,9 @@
 #include "GLFWInputDevice.h"
 
 #include "Core/App.h"
+#include "Windowing/Window.h"
+
+#include <GLFW/glfw3.h>
 
 namespace gore
 {
@@ -33,6 +36,9 @@ void GLFWInputSystem::Initialize()
 {
     m_Keyboard = new GLFWKeyboard(m_App->GetWindow());
     m_Mouse = new GLFWMouse(m_App->GetWindow());
+
+    if (glfwRawMouseMotionSupported())
+        glfwSetInputMode(m_App->GetWindow()->Get(), GLFW_RAW_MOUSE_MOTION, GLFW_TRUE);
 }
 
 void GLFWInputSystem::Update()

--- a/src/Input/GLFW/GLFWInputSystem.cpp
+++ b/src/Input/GLFW/GLFWInputSystem.cpp
@@ -1,0 +1,50 @@
+#include "Prefix.h"
+
+#include "GLFWInputSystem.h"
+#include "GLFWInputDevice.h"
+
+#include "Core/App.h"
+
+namespace gore
+{
+
+GLFWInputSystem::GLFWInputSystem(App* app) :
+    InputSystem(app),
+    m_Keyboard(nullptr),
+    m_Mouse(nullptr)
+{
+}
+
+GLFWInputSystem::~GLFWInputSystem()
+{
+}
+
+Keyboard* GLFWInputSystem::GetKeyboard() const
+{
+    return m_Keyboard;
+}
+
+Mouse* GLFWInputSystem::GetMouse() const
+{
+    return m_Mouse;
+}
+
+void GLFWInputSystem::Initialize()
+{
+    m_Keyboard = new GLFWKeyboard(m_App->GetWindow());
+    m_Mouse = new GLFWMouse(m_App->GetWindow());
+}
+
+void GLFWInputSystem::Update()
+{
+    m_Keyboard->Update();
+    m_Mouse->Update();
+}
+
+void GLFWInputSystem::Shutdown()
+{
+    delete m_Keyboard;
+    delete m_Mouse;
+}
+
+} // namespace gore

--- a/src/Input/GLFW/GLFWInputSystem.h
+++ b/src/Input/GLFW/GLFWInputSystem.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Input/InputSystem.h"
+
+namespace gore
+{
+
+class GLFWKeyboard;
+class GLFWMouse;
+
+class GLFWInputSystem final : public InputSystem
+{
+public:
+    explicit GLFWInputSystem(App* app);
+    ~GLFWInputSystem() final;
+
+    NON_COPYABLE(GLFWInputSystem);
+
+    [[nodiscard]] Keyboard* GetKeyboard() const final;
+    [[nodiscard]] Mouse* GetMouse() const final;
+
+    void Initialize() final;
+    void Update() final;
+    void Shutdown() final;
+
+private:
+    GLFWKeyboard* m_Keyboard;
+    GLFWMouse* m_Mouse;
+};
+
+} // namespace gore

--- a/src/Input/InputAction.cpp
+++ b/src/Input/InputAction.cpp
@@ -1,0 +1,61 @@
+#include "Prefix.h"
+
+#include "InputAction.h"
+
+#include <utility>
+
+namespace gore
+{
+
+InputAction::InputAction(InputDevice* device, std::string name, InputType type,
+                         std::function<bool()> updateDigitalFunction,
+                         std::function<float()> updateAnalogFunction) :
+    m_Name(std::move(name)),
+    m_Type(type),
+    m_Device(device),
+    m_DigitalState(),
+    m_AnalogState(),
+    m_UpdateDigitalFunction(std::move(updateDigitalFunction)),
+    m_UpdateAnalogFunction(std::move(updateAnalogFunction))
+{
+}
+
+InputAction::~InputAction()
+{
+}
+
+bool InputAction::Pressed() const
+{
+    return !m_DigitalState.lastState && m_DigitalState.state;
+}
+
+bool InputAction::Released() const
+{
+    return m_DigitalState.lastState && !m_DigitalState.state;
+}
+
+bool InputAction::Held() const
+{
+    return m_DigitalState.state;
+}
+
+float InputAction::Value() const
+{
+    return m_AnalogState.state;
+}
+
+float InputAction::Delta() const
+{
+    return m_AnalogState.state - m_AnalogState.lastState;
+}
+
+void InputAction::UpdateState()
+{
+    m_DigitalState.lastState = m_DigitalState.state;
+    m_DigitalState.state = m_UpdateDigitalFunction();
+
+    m_AnalogState.lastState = m_AnalogState.state;
+    m_AnalogState.state = m_UpdateAnalogFunction();
+}
+
+} // namespace gore

--- a/src/Input/InputAction.h
+++ b/src/Input/InputAction.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "Export.h"
+
+#include "InputEnums.h"
+#include "InputDevice.h"
+
+#include <string>
+#include <functional>
+
+namespace gore
+{
+
+ENGINE_CLASS(InputAction)
+{
+public:
+    InputAction(InputDevice* device, std::string name, InputType type,
+                std::function<bool()> updateDigitalFunction = []() { return false; },
+                std::function<float()> updateAnalogFunction = []() { return 0.0f; });
+    ~InputAction();
+
+    NON_COPYABLE(InputAction);
+
+    [[nodiscard]] InputType Type() const { return m_Type; }
+    [[nodiscard]] const std::string& Name() const { return m_Name; }
+
+    [[nodiscard]] bool Pressed() const;
+    [[nodiscard]] bool Released() const;
+    [[nodiscard]] bool Held() const;
+
+    [[nodiscard]] float Value() const;
+    [[nodiscard]] float Delta() const;
+
+    void UpdateState();
+
+private:
+    friend class InputSystem;
+
+    std::string m_Name;
+    InputType m_Type;
+
+    InputDevice* m_Device;
+
+    InputDevice::DigitalState m_DigitalState;
+    InputDevice::AnalogState m_AnalogState;
+
+    std::function<bool()> m_UpdateDigitalFunction;
+    std::function<float()> m_UpdateAnalogFunction;
+};
+
+} // namespace gore

--- a/src/Input/InputDevice.cpp
+++ b/src/Input/InputDevice.cpp
@@ -1,0 +1,86 @@
+#include "Prefix.h"
+
+#include "InputDevice.h"
+
+#include <cstring>
+
+namespace gore
+{
+
+InputDevice::~InputDevice()
+{
+}
+
+Keyboard::Keyboard() :
+    InputDevice(),
+    m_Keys()
+{
+    memset(m_Keys, 0, sizeof(m_Keys));
+}
+
+Keyboard::~Keyboard()
+{
+}
+
+bool Keyboard::KeyState(KeyCode key) const
+{
+    const DigitalState& state = m_Keys[static_cast<int>(key)];
+    return state.state;
+}
+
+bool Keyboard::KeyPressed(KeyCode key) const
+{
+    const DigitalState& state = m_Keys[static_cast<int>(key)];
+    return state.state && !state.lastState;
+}
+
+bool Keyboard::KeyReleased(KeyCode key) const
+{
+    const DigitalState& state = m_Keys[static_cast<int>(key)];
+    return !state.state && state.lastState;
+}
+
+Mouse::Mouse() :
+    InputDevice(),
+    m_Buttons(),
+    m_Movements()
+{
+    memset(m_Buttons, 0, sizeof(m_Buttons));
+    memset(m_Movements, 0, sizeof(m_Movements));
+}
+
+Mouse::~Mouse()
+{
+}
+
+bool Mouse::ButtonState(MouseButtonCode button) const
+{
+    const DigitalState& state = m_Buttons[static_cast<int>(button)];
+    return state.state;
+}
+
+bool Mouse::ButtonPressed(MouseButtonCode button) const
+{
+    const DigitalState& state = m_Buttons[static_cast<int>(button)];
+    return state.state && !state.lastState;
+}
+
+bool Mouse::ButtonReleased(MouseButtonCode button) const
+{
+    const DigitalState& state = m_Buttons[static_cast<int>(button)];
+    return !state.state && state.lastState;
+}
+
+float Mouse::Get(MouseMovementCode movement) const
+{
+    const AnalogState& state = m_Movements[static_cast<int>(movement)];
+    return state.state;
+}
+
+float Mouse::GetDelta(MouseMovementCode movement) const
+{
+    const AnalogState& state = m_Movements[static_cast<int>(movement)];
+    return state.state - state.lastState;
+}
+
+} // namespace gore

--- a/src/Input/InputDevice.cpp
+++ b/src/Input/InputDevice.cpp
@@ -1,14 +1,39 @@
 #include "Prefix.h"
 
 #include "InputDevice.h"
+#include "InputAction.h"
 
 #include <cstring>
 
 namespace gore
 {
 
+InputDevice::InputDevice() :
+    m_Actions()
+{
+}
+
 InputDevice::~InputDevice()
 {
+}
+
+InputAction* InputDevice::GetAction(const std::string& name) const
+{
+    auto it = m_Actions.find(name);
+    if (it == m_Actions.end())
+    {
+        return nullptr;
+    }
+
+    return it->second;
+}
+
+void InputDevice::UpdateAllActions()
+{
+    for (auto& action : m_Actions)
+    {
+        action.second->UpdateState();
+    }
 }
 
 Keyboard::Keyboard() :
@@ -38,6 +63,24 @@ bool Keyboard::KeyReleased(KeyCode key) const
 {
     const DigitalState& state = m_Keys[static_cast<int>(key)];
     return !state.state && state.lastState;
+}
+
+InputAction* Keyboard::RegisterAction(const std::string& name, KeyCode positiveKey, KeyCode negativeKey)
+{
+    std::function<bool()> digitalUpdate = [this, positiveKey]()
+    { return KeyState(positiveKey); };
+    std::function<float()> analogUpdate = [this, positiveKey, negativeKey]()
+    {
+        float result = 0.0f;
+        if (KeyState(positiveKey))
+            result += 1.0f;
+        if (KeyState(negativeKey))
+            result -= 1.0f;
+        return result;
+    };
+    const auto& res = m_Actions.emplace(name, new InputAction(this, name, InputType::Digital, digitalUpdate, analogUpdate));
+
+    return res.first->second;
 }
 
 Mouse::Mouse() :
@@ -81,6 +124,39 @@ float Mouse::GetDelta(MouseMovementCode movement) const
 {
     const AnalogState& state = m_Movements[static_cast<int>(movement)];
     return state.state - state.lastState;
+}
+
+InputAction* Mouse::RegisterAction(const std::string& name, MouseButtonCode positiveButton, MouseButtonCode negativeButton)
+{
+    std::function<bool()> digitalUpdate = [this, positiveButton]()
+    { return ButtonState(positiveButton); };
+    std::function<float()> analogUpdate = [this, positiveButton, negativeButton]()
+    {
+        float result = 0.0f;
+        if (ButtonState(positiveButton))
+            result += 1.0f;
+        if (static_cast<int>(negativeButton) < static_cast<int>(MouseButtonCode::Count))
+        {
+            if (ButtonState(negativeButton))
+                result -= 1.0f;
+        }
+        return result;
+    };
+    const auto& res = m_Actions.emplace(name, new InputAction(this, name, InputType::Digital, digitalUpdate, analogUpdate));
+
+    return res.first->second;
+}
+
+InputAction* Mouse::RegisterAction(const std::string& name, MouseMovementCode movement)
+{
+    std::function<bool()> digitalUpdate = [this, movement]()
+    { return GetDelta(movement) > 0; };
+    std::function<float()> analogUpdate = [this, movement]()
+    { return Get(movement); };
+
+    const auto& res = m_Actions.emplace(name, new InputAction(this, name, InputType::Analog, digitalUpdate, analogUpdate));
+
+    return res.first->second;
 }
 
 } // namespace gore

--- a/src/Input/InputDevice.h
+++ b/src/Input/InputDevice.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "Export.h"
+
+#include "KeyCode.h"
+
+namespace gore
+{
+
+ENGINE_CLASS(InputDevice)
+{
+public:
+    InputDevice() = default;
+    virtual ~InputDevice();
+
+    NON_COPYABLE(InputDevice);
+
+    virtual void Update() = 0;
+
+protected:
+    struct DigitalState
+    {
+        bool state;
+        bool lastState;
+    };
+
+    struct AnalogState
+    {
+        float state;
+        float lastState;
+    };
+};
+
+ENGINE_CLASS(Keyboard) : public InputDevice
+{
+public:
+    Keyboard();
+    virtual ~Keyboard();
+
+    NON_COPYABLE(Keyboard);
+
+    [[nodiscard]] bool KeyState(KeyCode key) const;
+    [[nodiscard]] bool KeyPressed(KeyCode key) const;
+    [[nodiscard]] bool KeyReleased(KeyCode key) const;
+
+protected:
+    DigitalState m_Keys[static_cast<int>(KeyCode::Count)];
+};
+
+ENGINE_CLASS(Mouse) : public InputDevice
+{
+public:
+    Mouse();
+    virtual ~Mouse();
+
+    NON_COPYABLE(Mouse);
+
+    [[nodiscard]] bool ButtonState(MouseButtonCode button) const;
+    [[nodiscard]] bool ButtonPressed(MouseButtonCode button) const;
+    [[nodiscard]] bool ButtonReleased(MouseButtonCode button) const;
+
+    [[nodiscard]] float Get(MouseMovementCode movement) const;
+    [[nodiscard]] float GetDelta(MouseMovementCode movement) const;
+
+    virtual void SetCursorShow(bool show) = 0;
+
+protected:
+    DigitalState m_Buttons[static_cast<int>(MouseButtonCode::Count)];
+    AnalogState m_Movements[static_cast<int>(MouseMovementCode::Count)];
+};
+
+}

--- a/src/Input/InputDevice.h
+++ b/src/Input/InputDevice.h
@@ -62,7 +62,7 @@ public:
     [[nodiscard]] float Get(MouseMovementCode movement) const;
     [[nodiscard]] float GetDelta(MouseMovementCode movement) const;
 
-    virtual void SetCursorShow(bool show) = 0;
+    virtual void SetCursorShow(bool show) const = 0;
 
 protected:
     DigitalState m_Buttons[static_cast<int>(MouseButtonCode::Count)];

--- a/src/Input/InputDevice.h
+++ b/src/Input/InputDevice.h
@@ -2,22 +2,31 @@
 
 #include "Export.h"
 
-#include "KeyCode.h"
+#include "InputEnums.h"
+
+#include <map>
+#include <string>
 
 namespace gore
 {
 
+class InputAction;
+
 ENGINE_CLASS(InputDevice)
 {
 public:
-    InputDevice() = default;
+    InputDevice();
     virtual ~InputDevice();
 
     NON_COPYABLE(InputDevice);
 
     virtual void Update() = 0;
 
+    [[nodiscard]] InputAction* GetAction(const std::string& name) const;
+
 protected:
+    friend class InputAction;
+
     struct DigitalState
     {
         bool state;
@@ -29,6 +38,10 @@ protected:
         float state;
         float lastState;
     };
+
+    std::map<std::string, InputAction*> m_Actions;
+
+    void UpdateAllActions();
 };
 
 ENGINE_CLASS(Keyboard) : public InputDevice
@@ -42,6 +55,8 @@ public:
     [[nodiscard]] bool KeyState(KeyCode key) const;
     [[nodiscard]] bool KeyPressed(KeyCode key) const;
     [[nodiscard]] bool KeyReleased(KeyCode key) const;
+
+    InputAction* RegisterAction(const std::string& name, KeyCode positiveKey, KeyCode negativeKey = KeyCode::Unknown);
 
 protected:
     DigitalState m_Keys[static_cast<int>(KeyCode::Count)];
@@ -63,6 +78,9 @@ public:
     [[nodiscard]] float GetDelta(MouseMovementCode movement) const;
 
     virtual void SetCursorShow(bool show) const = 0;
+
+    InputAction* RegisterAction(const std::string& name, MouseButtonCode positiveButton, MouseButtonCode negativeButton = MouseButtonCode::Count);
+    InputAction* RegisterAction(const std::string& name, MouseMovementCode movement);
 
 protected:
     DigitalState m_Buttons[static_cast<int>(MouseButtonCode::Count)];

--- a/src/Input/InputEnums.h
+++ b/src/Input/InputEnums.h
@@ -166,7 +166,7 @@ enum class KeyCode
     LeftWindows,
     RightWindows,
     Menu,
-    ErrorKey,
+    Unknown,
 
     Count
 };
@@ -193,7 +193,8 @@ enum class MouseMovementCode
 {
     X,
     Y,
-    ScrollWheel,
+    ScrollX,
+    ScrollY,
 
     Count
 };

--- a/src/Input/InputSystem.cpp
+++ b/src/Input/InputSystem.cpp
@@ -1,0 +1,28 @@
+#include "Prefix.h"
+
+#include "InputSystem.h"
+
+#include "Core/App.h"
+
+namespace gore
+{
+
+static InputSystem* s_InputSystem = nullptr;
+
+InputSystem::InputSystem(App* app) :
+    System(app)
+{
+    s_InputSystem = this;
+}
+
+InputSystem::~InputSystem()
+{
+    s_InputSystem = nullptr;
+}
+
+const InputSystem* InputSystem::Get()
+{
+    return s_InputSystem;
+}
+
+} // namespace gore

--- a/src/Input/InputSystem.h
+++ b/src/Input/InputSystem.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Export.h"
+
+#include "InputDevice.h"
+#include "Core/System.h"
+
+namespace gore
+{
+
+ENGINE_CLASS(InputSystem) : public System
+{
+public:
+    explicit InputSystem(App* app);
+    virtual ~InputSystem();
+
+    NON_COPYABLE(InputSystem);
+
+    [[nodiscard]] virtual Keyboard* GetKeyboard() const = 0;
+    [[nodiscard]] virtual Mouse* GetMouse() const = 0;
+
+    static const InputSystem* Get();
+};
+
+}

--- a/src/Input/InputSystem.h
+++ b/src/Input/InputSystem.h
@@ -3,6 +3,7 @@
 #include "Export.h"
 
 #include "InputDevice.h"
+#include "InputAction.h"
 #include "Core/System.h"
 
 namespace gore

--- a/src/Input/KeyCode.h
+++ b/src/Input/KeyCode.h
@@ -1,0 +1,201 @@
+#pragma once
+
+namespace gore
+{
+
+enum class InputType
+{
+    Digital,
+    Analog
+};
+
+enum class JoystickButtonCode
+{
+    DPadUp        = 0x0001, // DPad Up
+    DPadDown      = 0x0002, // DPad Down
+    DPadLeft      = 0x0004, // DPad Left
+    DPadRight     = 0x0008, // DPad Right
+    Start         = 0x0010, // Start / Menu / Options
+    Back          = 0x0020, // Back / View / Share
+    LeftThumb     = 0x0040, // Left Thumb Button / L3
+    RightThumb    = 0x0080, // Right Thumb Button / R3
+    LeftShoulder  = 0x0100, // Left Shoulder Button / LB / L1
+    RightShoulder = 0x0200, // Right Shoulder Button / RB / R1
+    ButtonSouth   = 0x1000, // A on Xbox, B on Nintendo, Cross on PS
+    ButtonEast    = 0x2000, // B on Xbox, A on Nintendo, Circle on PS
+    ButtonWest    = 0x4000, // X on Xbox, Y on Nintendo, Square on PS
+    ButtonNorth   = 0x8000, // Y on Xbox, X on Nintendo, Triangle on PS
+
+    Menu    = Start,
+    Options = Start,
+    View    = Back,
+    Share   = Back,
+
+    LB = LeftShoulder,
+    L1 = LeftShoulder,
+    RB = RightShoulder,
+    R1 = RightShoulder,
+
+    L3 = LeftThumb,
+    R3 = RightThumb,
+
+    Cross    = ButtonSouth,
+    Circle   = ButtonEast,
+    Square   = ButtonWest,
+    Triangle = ButtonNorth,
+};
+
+enum class JoystickAxisCode
+{
+    LT,        // Left Trigger
+    RT,        // Right Trigger
+    LX,        // Left Thumb Horizontal
+    LY,        // Left Thumb Vertical
+    RX,        // Right Thumb Horizontal
+    RY,        // Right Thumb Vertical
+    ErrorAxis, // Doesn't exist
+
+    L2 = LT,
+    R2 = RT,
+};
+
+enum class KeyCode
+{
+    Backspace,
+    Delete,
+    Tab,
+    Return,
+    Esc,
+    Space,
+    Keypad0,
+    Keypad1,
+    Keypad2,
+    Keypad3,
+    Keypad4,
+    Keypad5,
+    Keypad6,
+    Keypad7,
+    Keypad8,
+    Keypad9,
+    KeypadPeriod,
+    KeypadDivide,
+    KeypadMultiply,
+    KeypadMinus,
+    KeypadPlus,
+    KeypadEnter,
+    Up,
+    Down,
+    Right,
+    Left,
+    Insert,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+    F1,
+    F2,
+    F3,
+    F4,
+    F5,
+    F6,
+    F7,
+    F8,
+    F9,
+    F10,
+    F11,
+    F12,
+    F13,
+    F14,
+    F15,
+    Number0,
+    Number1,
+    Number2,
+    Number3,
+    Number4,
+    Number5,
+    Number6,
+    Number7,
+    Number8,
+    Number9,
+    Quote,
+    Comma,
+    Minus,
+    Period,
+    Slash,
+    Semicolon,
+    Equal,
+    LeftBracket,
+    Backslash,
+    RightBracket,
+    BackQuote,
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+    M,
+    N,
+    O,
+    P,
+    Q,
+    R,
+    S,
+    T,
+    U,
+    V,
+    W,
+    X,
+    Y,
+    Z,
+    NumLock,
+    CapsLock,
+    ScrollLock,
+    RightShift,
+    LeftShift,
+    RightControl,
+    LeftControl,
+    RightAlt,
+    LeftAlt,
+    LeftWindows,
+    RightWindows,
+    Menu,
+    ErrorKey,
+
+    Count
+};
+
+enum class MouseButtonCode
+{
+    Button0,
+    Button1,
+    Button2,
+    Button3,
+    Button4,
+    Button5,
+    Button6,
+    Button7,
+
+    Count,
+
+    Left   = Button0,
+    Right  = Button1,
+    Middle = Button2,
+};
+
+enum class MouseMovementCode
+{
+    X,
+    Y,
+    ScrollWheel,
+
+    Count
+};
+
+} // namespace gore

--- a/src/Prefix.h
+++ b/src/Prefix.h
@@ -89,3 +89,23 @@
 #ifdef None
     #undef None
 #endif
+
+#ifdef Button1
+    #undef Button1
+#endif
+
+#ifdef Button2
+    #undef Button2
+#endif
+
+#ifdef Button3
+    #undef Button3
+#endif
+
+#ifdef Button4
+    #undef Button4
+#endif
+
+#ifdef Button5
+    #undef Button5
+#endif

--- a/src/Windowing/Window.h
+++ b/src/Windowing/Window.h
@@ -19,6 +19,8 @@ public:
 
     NON_COPYABLE(Window);
 
+    [[nodiscard]] GLFWwindow* Get() const { return m_Window; }
+
     void GetSize(int* width, int* height) const;
 
     [[nodiscard]] void* GetNativeHandle() const


### PR DESCRIPTION
Add Input System supporting potentially multiple backends. Currently only using GLFW as backend.

Provide different level of APIs to access input data.

Use `InputDevice` class to directly access an input device, such as Mouse and Keyboard, or register `InputAction`s from `InputDevice` to define an action.

See example on `test-input` branch.