### PR TITLE
Fix InputAction memory leak

### DIFF
--- a/src/Input/InputAction.cpp
+++ b/src/Input/InputAction.cpp
@@ -7,6 +7,17 @@
 namespace gore
 {
 
+InputAction::InputAction() :
+    m_Name(),
+    m_Type(InputType::Digital),
+    m_Device(nullptr),
+    m_DigitalState(),
+    m_AnalogState(),
+    m_UpdateDigitalFunction([]() { return false; }),
+    m_UpdateAnalogFunction([]() { return 0.0f; })
+{
+}
+
 InputAction::InputAction(InputDevice* device, std::string name, InputType type,
                          std::function<bool()> updateDigitalFunction,
                          std::function<float()> updateAnalogFunction) :
@@ -20,8 +31,32 @@ InputAction::InputAction(InputDevice* device, std::string name, InputType type,
 {
 }
 
+InputAction::InputAction(InputAction&& other) noexcept :
+    m_Name(std::move(other.m_Name)),
+    m_Type(other.m_Type),
+    m_Device(other.m_Device),
+    m_DigitalState(other.m_DigitalState),
+    m_AnalogState(other.m_AnalogState),
+    m_UpdateDigitalFunction(std::move(other.m_UpdateDigitalFunction)),
+    m_UpdateAnalogFunction(std::move(other.m_UpdateAnalogFunction))
+{
+}
+
 InputAction::~InputAction()
 {
+}
+
+InputAction& InputAction::operator=(InputAction&& other) noexcept
+{
+    m_Name = std::move(other.m_Name);
+    m_Type = other.m_Type;
+    m_Device = other.m_Device;
+    m_DigitalState = other.m_DigitalState;
+    m_AnalogState = other.m_AnalogState;
+    m_UpdateDigitalFunction = std::move(other.m_UpdateDigitalFunction);
+    m_UpdateAnalogFunction = std::move(other.m_UpdateAnalogFunction);
+
+    return *this;
 }
 
 bool InputAction::Pressed() const

--- a/src/Input/InputAction.h
+++ b/src/Input/InputAction.h
@@ -14,12 +14,8 @@ namespace gore
 ENGINE_CLASS(InputAction)
 {
 public:
-    InputAction(InputDevice* device, std::string name, InputType type,
-                std::function<bool()> updateDigitalFunction = []() { return false; },
-                std::function<float()> updateAnalogFunction = []() { return 0.0f; });
+    InputAction(InputAction&& other) noexcept;
     ~InputAction();
-
-    NON_COPYABLE(InputAction);
 
     [[nodiscard]] InputType Type() const { return m_Type; }
     [[nodiscard]] const std::string& Name() const { return m_Name; }
@@ -35,6 +31,14 @@ public:
 
 private:
     friend class InputSystem;
+    friend class InputDevice;
+
+    InputAction();
+    InputAction(InputDevice* device, std::string name, InputType type,
+                std::function<bool()> updateDigitalFunction = []() { return false; },
+                std::function<float()> updateAnalogFunction = []() { return 0.0f; });
+
+    InputAction& operator=(InputAction&& other) noexcept;
 
     std::string m_Name;
     InputType m_Type;

--- a/src/Input/InputDevice.h
+++ b/src/Input/InputDevice.h
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <string>
+#include <functional>
 
 namespace gore
 {
@@ -22,7 +23,7 @@ public:
 
     virtual void Update() = 0;
 
-    [[nodiscard]] InputAction* GetAction(const std::string& name) const;
+    [[nodiscard]] const InputAction* GetAction(const std::string& name) const;
 
 protected:
     friend class InputAction;
@@ -39,7 +40,11 @@ protected:
         float lastState;
     };
 
-    std::map<std::string, InputAction*> m_Actions;
+    std::map<std::string, InputAction> m_Actions;
+
+    InputAction* AddAction(const std::string& name, InputType type,
+                           std::function<bool()> updateDigitalFunction = []() { return false; },
+                           std::function<float()> updateAnalogFunction = []() { return 0.0f; });
 
     void UpdateAllActions();
 };


### PR DESCRIPTION
The original code store `InputAction`s in a map as pointers, but after they are newed they are not properly deleted.

The new code store them as objects thus can be automatically destroyed when input device is destroyed.