### PR TITLE
Transform Hierarchy

### DIFF
--- a/sample/App/SampleApp.cpp
+++ b/sample/App/SampleApp.cpp
@@ -48,8 +48,8 @@ void SampleApp::Initialize()
     gore::GameObject* gameObject = scene->NewObject();
     gameObject->SetName("TestObject O, T&R&S");
 
-    auto pSelfRotate = gameObject->AddComponent<SelfRotate>();
-    auto pSelfScale = gameObject->AddComponent<SelfScaleInBetweenRange>();
+    auto pSelfRotate           = gameObject->AddComponent<SelfRotate>();
+    auto pSelfScale            = gameObject->AddComponent<SelfScaleInBetweenRange>();
     auto pSelfMoveBackAndForth = gameObject->AddComponent<SelfMoveBackAndForth>();
 
     const float distance = 2.5f;
@@ -59,44 +59,44 @@ void SampleApp::Initialize()
     gameObject->GetTransform()->SetLocalPosition(gore::Vector3::Left * distance);
     pSelfScale = gameObject->AddComponent<SelfScaleInBetweenRange>();
     pSelfScale->SetMinMaxScale(0.5f, 1.5f);
-    pSelfMoveBackAndForth = gameObject->AddComponent<SelfMoveBackAndForth>();
+    pSelfMoveBackAndForth              = gameObject->AddComponent<SelfMoveBackAndForth>();
     pSelfMoveBackAndForth->m_Direction = gore::Vector3::Left;
-    auto pLeftObject = gameObject;
+    auto pLeftObject                   = gameObject;
 
     gameObject = scene->NewObject();
     gameObject->SetName("TestObject R, R&S");
     gameObject->GetTransform()->SetLocalPosition(gore::Vector3::Right * distance);
-    pSelfRotate = gameObject->AddComponent<SelfRotate>();
+    pSelfRotate               = gameObject->AddComponent<SelfRotate>();
     pSelfRotate->m_RotateAxis = gore::Vector3::Right;
-    pSelfScale = gameObject->AddComponent<SelfScaleInBetweenRange>();
+    pSelfScale                = gameObject->AddComponent<SelfScaleInBetweenRange>();
     pSelfScale->SetMinMaxScale(0.5f, 1.5f);
     auto pRightObject = gameObject;
 
     gameObject = scene->NewObject();
     gameObject->SetName("TestObject F, T&R");
     gameObject->GetTransform()->SetLocalPosition(gore::Vector3::Forward * distance);
-    pSelfRotate = gameObject->AddComponent<SelfRotate>();
-    pSelfRotate->m_RotateAxis = gore::Vector3::Forward;
-    pSelfMoveBackAndForth = gameObject->AddComponent<SelfMoveBackAndForth>();
+    pSelfRotate                        = gameObject->AddComponent<SelfRotate>();
+    pSelfRotate->m_RotateAxis          = gore::Vector3::Forward;
+    pSelfMoveBackAndForth              = gameObject->AddComponent<SelfMoveBackAndForth>();
     pSelfMoveBackAndForth->m_Direction = gore::Vector3::Forward;
-    auto pForwardObject = gameObject;
+    auto pForwardObject                = gameObject;
 
     gameObject = scene->NewObject();
-    gameObject->SetName("TestObject B, T only");
+    gameObject->SetName("TestObject B, Translation only");
     gameObject->GetTransform()->SetLocalPosition(gore::Vector3::Backward * distance);
-    pSelfMoveBackAndForth = gameObject->AddComponent<SelfMoveBackAndForth>();
+    pSelfMoveBackAndForth              = gameObject->AddComponent<SelfMoveBackAndForth>();
     pSelfMoveBackAndForth->m_Direction = gore::Vector3::Backward;
-    auto pBackwardObject = gameObject;
+    auto pBackwardObject               = gameObject;
 
     gameObject = scene->NewObject();
-    gameObject->SetName("TestObject U, R only");
+    gameObject->SetName("TestObject U, Rotation only");
     gameObject->GetTransform()->SetLocalPosition(gore::Vector3::Up * distance);
-    pSelfRotate = gameObject->AddComponent<SelfRotate>();
+    pSelfRotate               = gameObject->AddComponent<SelfRotate>();
     pSelfRotate->m_RotateAxis = gore::Vector3::Up;
-    auto pUpObject = gameObject;
+    auto pUpObject            = gameObject;
 
     gameObject = scene->NewObject();
-    gameObject->SetName("TestObject D, S only");
+    gameObject->SetName("TestObject D, Scale only");
     gameObject->GetTransform()->SetLocalPosition(gore::Vector3::Down * distance);
     pSelfScale = gameObject->AddComponent<SelfScaleInBetweenRange>();
     pSelfScale->SetMinMaxScale(0.5f, 1.5f);
@@ -106,23 +106,33 @@ void SampleApp::Initialize()
 
     gore::GameObject* childGameObject = scene->NewObject();
     childGameObject->SetName("ChildObject");
-    childGameObject->GetTransform()->SetParent(gameObject->GetTransform());
-    childGameObject->GetTransform()->SetLocalPosition(gore::Vector3::Right * 1.0f);
+    childGameObject->GetTransform()->SetParent(pUpObject->GetTransform());
+    childGameObject->GetTransform()->SetLocalPosition(gore::Vector3::Up * 1.0f);
     childGameObject->GetTransform()->SetLocalScale(gore::Vector3::One * 0.5f);
 
     auto grandChildGameObject = scene->NewObject();
     grandChildGameObject->SetName("GrandChildObject");
     grandChildGameObject->GetTransform()->SetParent(childGameObject->GetTransform());
-    grandChildGameObject->GetTransform()->SetLocalPosition(gore::Vector3::Forward * 1.0f);
-    grandChildGameObject->GetTransform()->SetLocalScale(gore::Vector3::One * 2.0f);
+    grandChildGameObject->GetTransform()->SetLocalPosition(gore::Vector3::Forward * 1.5f);
+    grandChildGameObject->GetTransform()->SetLocalScale(gore::Vector3::One * 0.7f);
 
     auto pPeriodicallySwitchParent = grandChildGameObject->AddComponent<PeriodicallySwitchParent>();
     pPeriodicallySwitchParent->SetParentAB(pLeftObject->GetTransform(), pForwardObject->GetTransform());
-    pPeriodicallySwitchParent->m_RecalculateLocalPosition = true;
+    pPeriodicallySwitchParent->m_RecalculateLocalPosition = false;
 
     pPeriodicallySwitchParent = childGameObject->AddComponent<PeriodicallySwitchParent>();
-    pPeriodicallySwitchParent->SetParentAB(pRightObject->GetTransform(), nullptr);
-    pPeriodicallySwitchParent->m_RecalculateLocalPosition = false;
+    pPeriodicallySwitchParent->SetParentAB(childGameObject->GetTransform()->GetParent(), nullptr);
+    pPeriodicallySwitchParent->m_RecalculateLocalPosition = true;
+
+    LOG_STREAM(DEBUG) << "Find ChildObject in pUpObject at Initialization, non-recursively: "
+                      << pUpObject->GetTransform()->Find("GrandChildObject")
+                      << std::endl;
+    LOG_STREAM(DEBUG) << "Find ChildObject in pUpObject at Initialization, recursively: "
+                      << pUpObject->GetTransform()->Find("GrandChildObject", true)
+                      << std::endl;
+    LOG_STREAM(DEBUG) << "GetRoot() of grandChildGameObject: "
+                      << grandChildGameObject->GetTransform()->GetRoot()->GetGameObject()->GetName()
+                      << std::endl;
 }
 
 void SampleApp::Update()

--- a/sample/App/SampleApp.cpp
+++ b/sample/App/SampleApp.cpp
@@ -22,6 +22,7 @@
 #include "Scripts/SelfScaleInBetweenRange.h"
 #include "Scripts/PeriodicallyChangeWorldTRS.h"
 #include "Scripts/SelfDestroyAfterSeconds.h"
+#include "Scripts/DeleteMultipleGameObjectsAfterSeconds.h"
 
 SampleApp::SampleApp(int argc, char** argv) :
     App(argc, argv)
@@ -132,7 +133,24 @@ void SampleApp::Initialize()
     pSelfScale                            = childGameObject->AddComponent<SelfScaleInBetweenRange>();
     pSelfScale->SetMinMaxScale(0.5f, 1.5f);
 
-    pUpObject->AddComponent<SelfDestroyAfterSeconds>();
+    childGameObject->AddComponent<SelfDestroyAfterSeconds>();
+
+    auto pLeftChildObject = scene->NewObject();
+    pLeftChildObject->SetName("LeftChildObject");
+    pLeftChildObject->GetTransform()->SetParent(pLeftObject->GetTransform());
+    pLeftChildObject->GetTransform()->SetLocalPosition(gore::Vector3::Left * 1.0f);
+    pLeftChildObject->GetTransform()->SetLocalScale(gore::Vector3::One * 0.5f);
+
+    auto pLeftGrandChildObject = scene->NewObject();
+    pLeftGrandChildObject->SetName("LeftGrandChildObject");
+    pLeftGrandChildObject->GetTransform()->SetParent(pLeftChildObject->GetTransform());
+    pLeftGrandChildObject->GetTransform()->SetLocalPosition((gore::Vector3::Forward + gore::Vector3::Left) * 1.5f);
+    pLeftGrandChildObject->GetTransform()->SetLocalScale(gore::Vector3::One * 0.7f);
+
+    std::vector<gore::GameObject*> destroyList = {pLeftObject, pRightObject, pLeftGrandChildObject};
+    auto pDeleteMultipleGameObjectsAfterSeconds =
+        cameraGameObject->AddComponent<DeleteMultipleGameObjectsAfterSeconds>();
+    pDeleteMultipleGameObjectsAfterSeconds->SetGameObjectsToDelete(destroyList, 3, 2.0f);
 
     LOG_STREAM(DEBUG) << "Find ChildObject in pUpObject at Initialization, non-recursively: "
                       << pUpObject->GetTransform()->Find("GrandChildObject")

--- a/sample/App/SampleApp.cpp
+++ b/sample/App/SampleApp.cpp
@@ -21,6 +21,7 @@
 #include "Scripts/SelfMoveBackAndForth.h"
 #include "Scripts/SelfScaleInBetweenRange.h"
 #include "Scripts/PeriodicallyChangeWorldTRS.h"
+#include "Scripts/SelfDestroyAfterSeconds.h"
 
 SampleApp::SampleApp(int argc, char** argv) :
     App(argc, argv)
@@ -107,8 +108,8 @@ void SampleApp::Initialize()
 
     gore::GameObject* childGameObject = scene->NewObject();
     childGameObject->SetName("ChildObject");
-//    childGameObject->GetTransform()->SetParent(pUpObject->GetTransform());
-     childGameObject->GetTransform()->SetParent(nullptr);
+    childGameObject->GetTransform()->SetParent(pUpObject->GetTransform());
+    //    childGameObject->GetTransform()->SetParent(nullptr);
     childGameObject->GetTransform()->SetLocalPosition(gore::Vector3::Up * 1.0f);
     childGameObject->GetTransform()->SetLocalScale(gore::Vector3::One * 0.5f);
 
@@ -128,8 +129,10 @@ void SampleApp::Initialize()
 
     auto pPeriodicallyChangeWorldTRS      = childGameObject->AddComponent<PeriodicallyChangeWorldTRS>();
     pPeriodicallyChangeWorldTRS->m_Period = 0.5f;
-    pSelfScale = childGameObject->AddComponent<SelfScaleInBetweenRange>();
+    pSelfScale                            = childGameObject->AddComponent<SelfScaleInBetweenRange>();
     pSelfScale->SetMinMaxScale(0.5f, 1.5f);
+
+    pUpObject->AddComponent<SelfDestroyAfterSeconds>();
 
     LOG_STREAM(DEBUG) << "Find ChildObject in pUpObject at Initialization, non-recursively: "
                       << pUpObject->GetTransform()->Find("GrandChildObject")

--- a/sample/App/SampleApp.cpp
+++ b/sample/App/SampleApp.cpp
@@ -44,7 +44,7 @@ void SampleApp::Initialize()
     gore::GameObject* gameObject = scene->NewObject();
     gameObject->SetName("TestObject");
 
-    LOG_STREAM(INFO) << (gameObject->transform->GetLocalPosition()) << std::endl;
+    LOG_STREAM(INFO) << (gameObject->GetTransform()->GetLocalPosition()) << std::endl;
 
     TestComponent* testComponent = gameObject->AddComponent<TestComponent>();
 }

--- a/sample/Scripts/CameraController.cpp
+++ b/sample/Scripts/CameraController.cpp
@@ -104,7 +104,7 @@ void CameraController::Update()
     // I believe rtm::quat_from_euler_angles is using XYZ rotation order:
     // because when using this function, the yaw and pitch are always rotated as expected and not affected by the roll,
     // which means roll(i.e. Z) is the last rotation.
-    transform->SetLocalRotation(gore::Quaternion::CreateFromYawPitchRoll(m_Yaw, m_Pitch, m_Roll));
+    transform->SetLocalRotation(gore::Quaternion::FromYawPitchRoll(m_Yaw, m_Pitch, m_Roll));
 
     gore::Camera* camera = m_GameObject->GetComponent<gore::Camera>();
     float fov = camera->GetPerspectiveFOV();

--- a/sample/Scripts/DeleteMultipleGameObjectsAfterSeconds.cpp
+++ b/sample/Scripts/DeleteMultipleGameObjectsAfterSeconds.cpp
@@ -1,0 +1,40 @@
+#include "DeleteMultipleGameObjectsAfterSeconds.h"
+
+#include "Core/Time.h"
+#include "Scene/Scene.h"
+#include "Object/GameObject.h"
+
+DeleteMultipleGameObjectsAfterSeconds::DeleteMultipleGameObjectsAfterSeconds(gore::GameObject* gameObject) :
+    Component(gameObject),
+    m_GameObjectsToDelete(),
+    m_GameObjectsToDeleteCount(0),
+    m_DelaySeconds(2.0f)
+{
+}
+
+DeleteMultipleGameObjectsAfterSeconds::~DeleteMultipleGameObjectsAfterSeconds() = default;
+
+void DeleteMultipleGameObjectsAfterSeconds::Start()
+{
+}
+
+void DeleteMultipleGameObjectsAfterSeconds::Update()
+{
+    auto deltaTime = GetDeltaTime();
+    if (m_GameObjectsToDelete.empty())
+        return;
+
+    m_DelaySeconds -= deltaTime;
+    if (m_DelaySeconds <= 0.0f)
+    {
+        GetGameObject()->GetScene()->DestroyMultipleObjects(m_GameObjectsToDelete.data(), m_GameObjectsToDeleteCount);
+        m_GameObjectsToDelete.clear();
+        GetGameObject()->RemoveComponent<DeleteMultipleGameObjectsAfterSeconds>();
+    }
+}
+void DeleteMultipleGameObjectsAfterSeconds::SetGameObjectsToDelete(const std::vector<gore::GameObject*>& gameObjectToDelete, int count, float delaySeconds)
+{
+    m_GameObjectsToDelete      = gameObjectToDelete;
+    m_GameObjectsToDeleteCount = count;
+    m_DelaySeconds             = delaySeconds;
+}

--- a/sample/Scripts/DeleteMultipleGameObjectsAfterSeconds.h
+++ b/sample/Scripts/DeleteMultipleGameObjectsAfterSeconds.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Object/Component.h"
+
+#include <vector>
+
+class DeleteMultipleGameObjectsAfterSeconds final : public gore::Component
+{
+public:
+    DECLARE_FUNCTIONS_DERIVED_FROM_GORE_COMPONENT(DeleteMultipleGameObjectsAfterSeconds);
+
+    void SetGameObjectsToDelete(const std::vector<gore::GameObject*>& gameObjectToDelete, int count, float delaySeconds);
+
+private:
+    std::vector<gore::GameObject*> m_GameObjectsToDelete;
+    int m_GameObjectsToDeleteCount;
+    float m_DelaySeconds;
+};

--- a/sample/Scripts/PeriodicallyChangeWorldTRS.cpp
+++ b/sample/Scripts/PeriodicallyChangeWorldTRS.cpp
@@ -1,0 +1,36 @@
+#include "PeriodicallyChangeWorldTRS.h"
+
+#include "Core/Time.h"
+#include "Object/GameObject.h"
+#include "Object/Transform.h"
+#include "Math/Vector3.h"
+#include "Math/Constants.h"
+
+PeriodicallyChangeWorldTRS::PeriodicallyChangeWorldTRS(gore::GameObject* gameObject) :
+    gore::Component(gameObject),
+    m_Period(1.0f),
+    m_TimePassed(0.0f),
+    m_CurrentIndex(0)
+{
+}
+
+PeriodicallyChangeWorldTRS::~PeriodicallyChangeWorldTRS() = default;
+
+void PeriodicallyChangeWorldTRS::Start()
+{
+}
+
+void PeriodicallyChangeWorldTRS::Update()
+{
+    m_TimePassed += GetDeltaTime();
+    if (m_TimePassed >= m_Period)
+    {
+        m_CurrentIndex++;
+        LOG_STREAM(INFO) << "PeriodicallyChangeWorldTRS Period triggered." << std::endl;
+        m_TimePassed = 0.0f;
+
+        auto transform = GetGameObject()->GetTransform();
+        //        transform->SetWorldPosition(transform->GetWorldPosition() + gore::Vector3::Up);
+        transform->SetWorldRotation(gore::Quaternion::FromAxisAngle(gore::Vector3::Right, gore::math::constants::PI / 10 * m_CurrentIndex));
+    }
+}

--- a/sample/Scripts/PeriodicallyChangeWorldTRS.cpp
+++ b/sample/Scripts/PeriodicallyChangeWorldTRS.cpp
@@ -31,6 +31,6 @@ void PeriodicallyChangeWorldTRS::Update()
 
         auto transform = GetGameObject()->GetTransform();
         //        transform->SetWorldPosition(transform->GetWorldPosition() + gore::Vector3::Up);
-        transform->SetWorldRotation(gore::Quaternion::FromAxisAngle(gore::Vector3::Right, gore::math::constants::PI / 10 * m_CurrentIndex));
+        transform->SetWorldRotation(transform->GetWorldRotation() * gore::Quaternion::FromAxisAngle(gore::Vector3::Right, gore::math::constants::PI / 10));
     }
 }

--- a/sample/Scripts/PeriodicallyChangeWorldTRS.h
+++ b/sample/Scripts/PeriodicallyChangeWorldTRS.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Object/Component.h"
+
+class PeriodicallyChangeWorldTRS final : public gore::Component
+{
+public:
+    DECLARE_FUNCTIONS_DERIVED_FROM_GORE_COMPONENT(PeriodicallyChangeWorldTRS);
+
+    float m_Period;
+
+private:
+    int m_CurrentIndex;
+    float m_TimePassed;
+};

--- a/sample/Scripts/PeriodicallySwitchParent.cpp
+++ b/sample/Scripts/PeriodicallySwitchParent.cpp
@@ -1,0 +1,52 @@
+#include "PeriodicallySwitchParent.h"
+
+#include "Core/Time.h"
+#include "Object/GameObject.h"
+
+PeriodicallySwitchParent::PeriodicallySwitchParent(gore::GameObject* gameObject) :
+    Component(gameObject),
+    m_ParentA(nullptr),
+    m_ParentB(nullptr),
+    m_Time(0.0f),
+    m_SwitchInterval(1.0f),
+    m_Switched(false),
+    m_RecalculateLocalPosition(true)
+{
+}
+
+PeriodicallySwitchParent::~PeriodicallySwitchParent() = default;
+
+void PeriodicallySwitchParent::Start()
+{
+}
+
+void PeriodicallySwitchParent::Update()
+{
+    m_Time += GetDeltaTime();
+
+    if (m_Time >= m_SwitchInterval)
+    {
+        m_Time     = 0.0f;
+        m_Switched = !m_Switched;
+
+        if (m_Switched)
+        {
+            GetGameObject()->GetTransform()->SetParent(m_ParentA, m_RecalculateLocalPosition);
+            LOG_STREAM(DEBUG) << "Switched parent to "
+                              << (m_ParentA == nullptr ? "Global space" : m_ParentA->GetGameObject()->GetName())
+                              << std::endl;
+        }
+        else
+        {
+            GetGameObject()->GetTransform()->SetParent(m_ParentB, m_RecalculateLocalPosition);
+            LOG_STREAM(DEBUG) << "Switched parent to "
+                              << (m_ParentB == nullptr ? "Global space" : m_ParentB->GetGameObject()->GetName())
+                              << std::endl;
+        }
+    }
+}
+void PeriodicallySwitchParent::SetParentAB(gore::Transform* parentA, gore::Transform* parentB)
+{
+    m_ParentA = parentA;
+    m_ParentB = parentB;
+}

--- a/sample/Scripts/PeriodicallySwitchParent.cpp
+++ b/sample/Scripts/PeriodicallySwitchParent.cpp
@@ -2,6 +2,7 @@
 
 #include "Core/Time.h"
 #include "Object/GameObject.h"
+#include "Input/InputSystem.h"
 
 PeriodicallySwitchParent::PeriodicallySwitchParent(gore::GameObject* gameObject) :
     Component(gameObject),
@@ -10,7 +11,8 @@ PeriodicallySwitchParent::PeriodicallySwitchParent(gore::GameObject* gameObject)
     m_Time(0.0f),
     m_SwitchInterval(1.0f),
     m_Switched(false),
-    m_RecalculateLocalPosition(true)
+    m_RecalculateLocalPosition(true),
+    m_Keyboard(gore::InputSystem::Get()->GetKeyboard())
 {
 }
 
@@ -24,7 +26,8 @@ void PeriodicallySwitchParent::Update()
 {
     m_Time += GetDeltaTime();
 
-    if (m_Time >= m_SwitchInterval)
+    //    if (m_Time >= m_SwitchInterval)
+    if (m_Keyboard->KeyPressed(gore::KeyCode::G))
     {
         m_Time     = 0.0f;
         m_Switched = !m_Switched;

--- a/sample/Scripts/PeriodicallySwitchParent.h
+++ b/sample/Scripts/PeriodicallySwitchParent.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Object/Component.h"
+#include "Object/Transform.h"
+
+class PeriodicallySwitchParent final : public gore::Component
+{
+public:
+    DECLARE_FUNCTIONS_DERIVED_FROM_GORE_COMPONENT(PeriodicallySwitchParent);
+
+    void SetParentAB(gore::Transform* parentA, gore::Transform* parentB);
+
+public:
+    gore::Transform* m_ParentA;
+    gore::Transform* m_ParentB;
+    float m_SwitchInterval;
+    bool m_RecalculateLocalPosition;
+
+private:
+    float m_Time;
+    bool m_Switched;
+};

--- a/sample/Scripts/PeriodicallySwitchParent.h
+++ b/sample/Scripts/PeriodicallySwitchParent.h
@@ -2,6 +2,7 @@
 
 #include "Object/Component.h"
 #include "Object/Transform.h"
+#include "Input/InputDevice.h"
 
 class PeriodicallySwitchParent final : public gore::Component
 {
@@ -19,4 +20,6 @@ public:
 private:
     float m_Time;
     bool m_Switched;
+
+    gore::Keyboard* m_Keyboard;
 };

--- a/sample/Scripts/SelfDestroyAfterSeconds.cpp
+++ b/sample/Scripts/SelfDestroyAfterSeconds.cpp
@@ -1,0 +1,26 @@
+#include "SelfDestroyAfterSeconds.h"
+
+#include "Core/Time.h"
+#include "Object/GameObject.h"
+#include "Scene/Scene.h"
+
+SelfDestroyAfterSeconds::SelfDestroyAfterSeconds(gore::GameObject* gameObject)
+    : Component(gameObject)
+    , m_SecondsToLive(3.0f)
+{
+}
+
+SelfDestroyAfterSeconds::~SelfDestroyAfterSeconds() = default;
+
+void SelfDestroyAfterSeconds::Start()
+{
+}
+
+void SelfDestroyAfterSeconds::Update()
+{
+    m_SecondsToLive -= GetDeltaTime();
+    if (m_SecondsToLive <= 0.0f)
+    {
+        GetGameObject()->Destroy();
+    }
+}

--- a/sample/Scripts/SelfDestroyAfterSeconds.cpp
+++ b/sample/Scripts/SelfDestroyAfterSeconds.cpp
@@ -4,9 +4,9 @@
 #include "Object/GameObject.h"
 #include "Scene/Scene.h"
 
-SelfDestroyAfterSeconds::SelfDestroyAfterSeconds(gore::GameObject* gameObject)
-    : Component(gameObject)
-    , m_SecondsToLive(3.0f)
+SelfDestroyAfterSeconds::SelfDestroyAfterSeconds(gore::GameObject* gameObject) :
+    Component(gameObject),
+    m_SecondsToLive(3.0f)
 {
 }
 

--- a/sample/Scripts/SelfDestroyAfterSeconds.h
+++ b/sample/Scripts/SelfDestroyAfterSeconds.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "Object/Component.h"
+
+class SelfDestroyAfterSeconds final : public gore::Component
+{
+public:
+    DECLARE_FUNCTIONS_DERIVED_FROM_GORE_COMPONENT(SelfDestroyAfterSeconds);
+
+public:
+    float m_SecondsToLive;
+};

--- a/sample/Scripts/SelfMoveBackAndForth.cpp
+++ b/sample/Scripts/SelfMoveBackAndForth.cpp
@@ -1,0 +1,30 @@
+#include "SelfMoveBackAndForth.h"
+
+#include "Core/Time.h"
+#include "Object/GameObject.h"
+#include "Object/Transform.h"
+
+#include <cmath>
+
+SelfMoveBackAndForth::SelfMoveBackAndForth(gore::GameObject* gameObject) :
+    Component(gameObject),
+    m_Direction(gore::Vector3::Forward),
+    m_Speed(1.0f),
+    m_FarthestDistance(1.0f)
+{
+}
+
+SelfMoveBackAndForth::~SelfMoveBackAndForth() = default;
+
+void SelfMoveBackAndForth::Start()
+{
+}
+
+void SelfMoveBackAndForth::Update()
+{
+    float totalTime = GetTotalTime();
+
+    gore::Vector3 position = GetGameObject()->GetTransform()->GetLocalPosition();
+    position += sinf(totalTime * m_Speed) * m_Direction * m_FarthestDistance * GetDeltaTime();
+    GetGameObject()->GetTransform()->SetLocalPosition(position);
+}

--- a/sample/Scripts/SelfMoveBackAndForth.cpp
+++ b/sample/Scripts/SelfMoveBackAndForth.cpp
@@ -26,5 +26,5 @@ void SelfMoveBackAndForth::Update()
 
     gore::Vector3 position = GetGameObject()->GetTransform()->GetLocalPosition();
     position += sinf(totalTime * m_Speed) * m_Direction * m_FarthestDistance * GetDeltaTime();
-    GetGameObject()->GetTransform()->SetLocalPosition(position);
+    GetGameObject()->GetTransform()->SetWorldPosition(position);
 }

--- a/sample/Scripts/SelfMoveBackAndForth.h
+++ b/sample/Scripts/SelfMoveBackAndForth.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Object/Component.h"
+#include "Math/Vector3.h"
+
+class SelfMoveBackAndForth final : public gore::Component
+{
+public:
+    DECLARE_FUNCTIONS_DERIVED_FROM_GORE_COMPONENT(SelfMoveBackAndForth);
+
+    gore::Vector3 m_Direction;
+    float m_Speed;
+    float m_FarthestDistance;
+};

--- a/sample/Scripts/SelfRotate.cpp
+++ b/sample/Scripts/SelfRotate.cpp
@@ -1,0 +1,24 @@
+#include "SelfRotate.h"
+
+#include "Core/Time.h"
+#include "Object/GameObject.h"
+#include "Object/Transform.h"
+
+SelfRotate::SelfRotate(gore::GameObject* gameObject) :
+    Component(gameObject),
+    m_RotateAxis(gore::Vector3::Up)
+{
+}
+
+SelfRotate::~SelfRotate() = default;
+
+void SelfRotate::Start()
+{
+}
+
+void SelfRotate::Update()
+{
+    float deltaTime = GetDeltaTime();
+
+    GetGameObject()->GetTransform()->RotateAroundAxis(m_RotateAxis, deltaTime);
+}

--- a/sample/Scripts/SelfRotate.cpp
+++ b/sample/Scripts/SelfRotate.cpp
@@ -3,10 +3,12 @@
 #include "Core/Time.h"
 #include "Object/GameObject.h"
 #include "Object/Transform.h"
+#include "Input/InputSystem.h"
 
 SelfRotate::SelfRotate(gore::GameObject* gameObject) :
     Component(gameObject),
-    m_RotateAxis(gore::Vector3::Up)
+    m_RotateAxis(gore::Vector3::Up),
+    m_Keyboard(gore::InputSystem::Get()->GetKeyboard())
 {
 }
 
@@ -18,6 +20,12 @@ void SelfRotate::Start()
 
 void SelfRotate::Update()
 {
+    if (m_Keyboard->KeyPressed(gore::KeyCode::T))
+    {
+        m_IsEnabled = !m_IsEnabled;
+    }
+    if (!m_IsEnabled) return;
+
     float deltaTime = GetDeltaTime();
 
     GetGameObject()->GetTransform()->RotateAroundAxis(m_RotateAxis, deltaTime);

--- a/sample/Scripts/SelfRotate.h
+++ b/sample/Scripts/SelfRotate.h
@@ -2,6 +2,7 @@
 
 #include "Object/Component.h"
 #include "Math/Vector3.h"
+#include "Input/InputDevice.h"
 
 class SelfRotate final : public gore::Component
 {
@@ -9,4 +10,8 @@ public:
     DECLARE_FUNCTIONS_DERIVED_FROM_GORE_COMPONENT(SelfRotate);
 
     gore::Vector3 m_RotateAxis;
+
+private:
+    gore::Keyboard* m_Keyboard;
+    bool m_IsEnabled;
 };

--- a/sample/Scripts/SelfRotate.h
+++ b/sample/Scripts/SelfRotate.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "Object/Component.h"
+#include "Math/Vector3.h"
+
+class SelfRotate final : public gore::Component
+{
+public:
+    DECLARE_FUNCTIONS_DERIVED_FROM_GORE_COMPONENT(SelfRotate);
+
+    gore::Vector3 m_RotateAxis;
+};

--- a/sample/Scripts/SelfScaleInBetweenRange.cpp
+++ b/sample/Scripts/SelfScaleInBetweenRange.cpp
@@ -26,7 +26,7 @@ void SelfScaleInBetweenRange::Update()
     float totalTime = GetTotalTime();
 
     m_CurrentScale = m_MinScale + sinf(totalTime * m_Speed) * (m_MaxScale - m_MinScale);
-    GetGameObject()->GetTransform()->SetLocalScale(gore::Vector3(m_CurrentScale));
+    GetGameObject()->GetTransform()->SetWorldScale(gore::Vector3(m_CurrentScale));
 }
 
 void SelfScaleInBetweenRange::SetMinMaxScale(float minScale, float maxScale)

--- a/sample/Scripts/SelfScaleInBetweenRange.cpp
+++ b/sample/Scripts/SelfScaleInBetweenRange.cpp
@@ -1,0 +1,36 @@
+#include "SelfScaleInBetweenRange.h"
+
+#include "Core/Time.h"
+#include "Object/GameObject.h"
+#include "Object/Transform.h"
+
+#include <cmath>
+
+SelfScaleInBetweenRange::SelfScaleInBetweenRange(gore::GameObject* gameObject) :
+    Component(gameObject),
+    m_MinScale(0.5f),
+    m_MaxScale(1.5f),
+    m_Speed(1.0f),
+    m_CurrentScale(1.0f)
+{
+}
+
+SelfScaleInBetweenRange::~SelfScaleInBetweenRange() = default;
+
+void SelfScaleInBetweenRange::Start()
+{
+}
+
+void SelfScaleInBetweenRange::Update()
+{
+    float totalTime = GetTotalTime();
+
+    m_CurrentScale = m_MinScale + sinf(totalTime * m_Speed) * (m_MaxScale - m_MinScale);
+    GetGameObject()->GetTransform()->SetLocalScale(gore::Vector3(m_CurrentScale));
+}
+
+void SelfScaleInBetweenRange::SetMinMaxScale(float minScale, float maxScale)
+{
+    m_MinScale = minScale;
+    m_MaxScale = maxScale;
+}

--- a/sample/Scripts/SelfScaleInBetweenRange.h
+++ b/sample/Scripts/SelfScaleInBetweenRange.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Object/Component.h"
+
+class SelfScaleInBetweenRange final : public gore::Component
+{
+public:
+    DECLARE_FUNCTIONS_DERIVED_FROM_GORE_COMPONENT(SelfScaleInBetweenRange);
+
+    void SetMinMaxScale(float minScale, float maxScale);
+
+    float m_MinScale;
+    float m_MaxScale;
+    float m_Speed;
+    float m_CurrentScale;
+};

--- a/sample/Scripts/TestComponent.cpp
+++ b/sample/Scripts/TestComponent.cpp
@@ -30,5 +30,5 @@ void TestComponent::Update()
 
     transform->RotateAroundAxis(gore::Vector3::Up, deltaTime);
 
-    // LOG_STREAM(DEBUG) << "TestComponent position:" << transform->GetLocalPosition() << " Quaternion: " << transform->GetLocalRotation() << std::endl;
+    // LOG_STREAM(DEBUG) << "TestComponent position:" << m_Transform->GetLocalPosition() << " Quaternion: " << m_Transform->GetLocalRotation() << std::endl;
 }

--- a/src/Math/Defines.h
+++ b/src/Math/Defines.h
@@ -5,10 +5,10 @@
 #define MATHF_SIMD_SET_VALUE_TYPE(SIMD_VALUE_TYPE) using SIMDValueType = SIMD_VALUE_TYPE;
 
 #define MATHF_SIMD_CONVERSION_WITH_VALUE_TYPE_DECLARATIONS(CLASS_NAME) \
-    operator SIMDValueType() const noexcept;                           \
-    explicit CLASS_NAME(const SIMDValueType& V) noexcept;              \
-    explicit CLASS_NAME(SIMDValueType&& V) noexcept;                   \
-    CLASS_NAME& operator=(const SIMDValueType& V) noexcept;
+    inline operator SIMDValueType() const noexcept;                    \
+    inline explicit CLASS_NAME(const SIMDValueType& V) noexcept;       \
+    inline explicit CLASS_NAME(SIMDValueType&& V) noexcept;            \
+    inline CLASS_NAME& operator=(const SIMDValueType& V) noexcept;
 
 #define MATHF_COMMON_COMPARISON_OPERATOR_DECLARATIONS(CLASS_NAME) \
     bool operator==(const CLASS_NAME& V) const noexcept;          \

--- a/src/Math/Matrix4x4.cpp
+++ b/src/Math/Matrix4x4.cpp
@@ -21,27 +21,6 @@ std::ostream& operator<<(std::ostream& os, const Matrix4x4& m) noexcept
     return os << "Matrix4x4()";
 }
 
-Matrix4x4::operator SIMDValueType() const noexcept
-{
-    return m_M;
-}
-
-Matrix4x4::Matrix4x4(const Matrix4x4::SIMDValueType& F) noexcept :
-    m_M(F)
-{
-}
-
-Matrix4x4::Matrix4x4(Matrix4x4::SIMDValueType&& F) noexcept :
-    m_M(std::move(F))
-{
-}
-
-Matrix4x4& Matrix4x4::operator=(const Matrix4x4::SIMDValueType& F) noexcept
-{
-    m_M = F;
-    return *this;
-}
-
 // Properties
 Vector3 Matrix4x4::GetUp() const noexcept
 {

--- a/src/Math/Matrix4x4.inl
+++ b/src/Math/Matrix4x4.inl
@@ -1,5 +1,27 @@
 #pragma once
 
+// Conversion with SIMDValueType
+Matrix4x4::operator SIMDValueType() const noexcept
+{
+    return m_M;
+}
+
+Matrix4x4::Matrix4x4(const Matrix4x4::SIMDValueType& F) noexcept :
+    m_M(F)
+{
+}
+
+Matrix4x4::Matrix4x4(Matrix4x4::SIMDValueType&& F) noexcept :
+    m_M(std::move(F))
+{
+}
+
+Matrix4x4& Matrix4x4::operator=(const Matrix4x4::SIMDValueType& F) noexcept
+{
+    m_M = F;
+    return *this;
+}
+
 //------------------------------------------------------------------------------
 // Comparison operators
 //------------------------------------------------------------------------------

--- a/src/Math/Quaternion.cpp
+++ b/src/Math/Quaternion.cpp
@@ -25,27 +25,6 @@ std::ostream& operator<<(std::ostream& os, const Quaternion& q) noexcept
               << ", " << temp[3] << ")";
 }
 
-Quaternion::operator SIMDValueType() const noexcept
-{
-    return m_Q;
-}
-
-Quaternion::Quaternion(const Quaternion::SIMDValueType& F) noexcept :
-    m_Q(F)
-{
-}
-
-Quaternion::Quaternion(Quaternion::SIMDValueType&& F) noexcept :
-    m_Q(std::move(F))
-{
-}
-
-Quaternion& Quaternion::operator=(const Quaternion::SIMDValueType& F) noexcept
-{
-    m_Q = F;
-    return *this;
-}
-
 Quaternion Quaternion::FromToRotation(const Vector3& fromDir, const Vector3& toDir) noexcept
 {
     // Melax, "The Shortest Arc Quaternion", Game Programming Gems, Charles River Media (2000).

--- a/src/Math/Quaternion.h
+++ b/src/Math/Quaternion.h
@@ -58,6 +58,9 @@ public:
     void Conjugate() noexcept;
     static void Conjugate(Quaternion & q) noexcept;
 
+    // I don't think it's necessary to divide by length squared in this engine
+    // Nobody will really use a non-normalized quaternion and treat it as a regular rotation
+    // So the function here in this engine is effectively the same as Conjugate()
     [[nodiscard]] Quaternion Inverse() const noexcept;
     void Invert() noexcept;
     static void Invert(Quaternion & q) noexcept;

--- a/src/Math/Quaternion.h
+++ b/src/Math/Quaternion.h
@@ -68,12 +68,12 @@ public:
     [[nodiscard]] Vector3 ToEuler() const noexcept;
 
     // Static functions
-    [[nodiscard]] static Quaternion CreateFromAxisAngle(const Vector3& axis, float angle) noexcept;
+    [[nodiscard]] static Quaternion FromAxisAngle(const Vector3& axis, float angle) noexcept;
     // Rotates about y-axis (yaw), then x-axis (pitch), then z-axis (roll)
-    [[nodiscard]] static Quaternion CreateFromYawPitchRoll(float yaw, float pitch, float roll) noexcept;
+    [[nodiscard]] static Quaternion FromYawPitchRoll(float yaw, float pitch, float roll) noexcept;
     // Rotates about y-axis (angles.y), then x-axis (angles.x), then z-axis (angles.z)
-    [[nodiscard]] static Quaternion CreateFromYawPitchRoll(const Vector3& angles) noexcept;
-    [[nodiscard]] static Quaternion CreateFromRotationMatrix(const Matrix4x4& M) noexcept;
+    [[nodiscard]] static Quaternion FromYawPitchRoll(const Vector3& angles) noexcept;
+    [[nodiscard]] static Quaternion FromRotationMatrix(const Matrix4x4& M) noexcept;
 
     [[nodiscard]] static Quaternion Lerp(const Quaternion& q1, const Quaternion& q2, float t) noexcept;
     [[nodiscard]] static Quaternion Slerp(const Quaternion& q1, const Quaternion& q2, float t) noexcept;

--- a/src/Math/Quaternion.inl
+++ b/src/Math/Quaternion.inl
@@ -170,17 +170,17 @@ inline float Quaternion::Dot(const Quaternion& q) const noexcept
 // Static functions
 //------------------------------------------------------------------------------
 
-inline Quaternion Quaternion::CreateFromAxisAngle(const Vector3& axis, float angle) noexcept
+inline Quaternion Quaternion::FromAxisAngle(const Vector3& axis, float angle) noexcept
 {
     return static_cast<Quaternion>(rtm::quat_from_axis_angle(static_cast<Vector3::SIMDValueType>(axis), angle));
 }
 
-inline Quaternion Quaternion::CreateFromYawPitchRoll(float yaw, float pitch, float roll) noexcept
+inline Quaternion Quaternion::FromYawPitchRoll(float yaw, float pitch, float roll) noexcept
 {
     return static_cast<Quaternion>(rtm::quat_from_euler(-yaw, roll, -pitch));
 }
 
-inline Quaternion Quaternion::CreateFromYawPitchRoll(const Vector3& angles) noexcept
+inline Quaternion Quaternion::FromYawPitchRoll(const Vector3& angles) noexcept
 {
     return static_cast<Quaternion>(rtm::quat_from_euler(-angles.y, angles.z, -angles.x));
 }

--- a/src/Math/Quaternion.inl
+++ b/src/Math/Quaternion.inl
@@ -1,5 +1,27 @@
 #pragma once
 
+// Conversion with SIMDValueType
+Quaternion::operator SIMDValueType() const noexcept
+{
+    return m_Q;
+}
+
+Quaternion::Quaternion(const Quaternion::SIMDValueType& F) noexcept :
+    m_Q(F)
+{
+}
+
+Quaternion::Quaternion(Quaternion::SIMDValueType&& F) noexcept :
+    m_Q(std::move(F))
+{
+}
+
+Quaternion& Quaternion::operator=(const Quaternion::SIMDValueType& F) noexcept
+{
+    m_Q = F;
+    return *this;
+}
+
 //------------------------------------------------------------------------------
 // Binary operators
 //------------------------------------------------------------------------------

--- a/src/Math/Quaternion.inl
+++ b/src/Math/Quaternion.inl
@@ -128,33 +128,17 @@ inline void Quaternion::Conjugate(Quaternion& q) noexcept
 
 inline Quaternion Quaternion::Inverse() const noexcept
 {
-    Quaternion result;
-    result.m_Q = rtm::quat_conjugate(result.m_Q);
-    result.m_Q = rtm::vector_div(
-        result.m_Q,
-        rtm::vector_set(static_cast<float>(rtm::quat_length_squared(result.m_Q))));
-    return result;
+    return Conjucated();
 }
 
 inline void Quaternion::Invert() noexcept
 {
     m_Q = rtm::quat_conjugate(m_Q);
-    m_Q = rtm::vector_div(
-        m_Q,
-        rtm::vector_set(static_cast<float>(rtm::quat_length_squared(m_Q))));
 }
 
 inline void Quaternion::Invert(Quaternion& q) noexcept
 {
-//    if (q.IsNormalized())
-//    {
-//        q.Conjugate();
-//        return;
-//    }
     q.m_Q = rtm::quat_conjugate(q.m_Q);
-    q.m_Q = rtm::vector_div(
-        q.m_Q,
-        rtm::vector_set(static_cast<float>(rtm::quat_length_squared(q.m_Q))));
 }
 
 inline float Quaternion::Dot(const Quaternion& q) const noexcept

--- a/src/Math/TQS.cpp
+++ b/src/Math/TQS.cpp
@@ -1,0 +1,12 @@
+#include "TQS.h"
+
+namespace gore
+{
+
+std::ostream& operator<<(std::ostream& os, const TQS& tqs) noexcept
+{
+    os << "TQS(" << tqs.t << ", " << tqs.q << ", " << tqs.s << ")";
+    return os;
+}
+
+} // namespace gore

--- a/src/Math/TQS.h
+++ b/src/Math/TQS.h
@@ -1,0 +1,163 @@
+#pragma once
+
+#include "Export.h"
+
+#include "Math/Defines.h"
+
+#include "Math/Vector3.h"
+#include "Math/Quaternion.h"
+
+#include "rtm/qvvf.h"
+
+namespace gore
+{
+
+struct Vector3;
+struct Matrix4x4;
+
+ENGINE_STRUCT(TQS)
+{
+    Vector3 t;
+    Quaternion q;
+    Vector3 s;
+
+    SHALLOW_COPYABLE(TQS);
+
+    explicit TQS() noexcept;
+    TQS(const Vector3& translation, const Quaternion& rotation, const Vector3& scale) noexcept;
+
+public:
+    [[nodiscard]] inline Matrix4x4 ToMatrix4x4() const noexcept;
+    [[nodiscard]] inline Matrix4x4 ToMatrix4x4Inverse() const noexcept;
+
+public:
+    [[nodiscard]] static TQS CreateIdentity() noexcept;
+    [[nodiscard]] static inline TQS Create(const Vector3& translation, const Quaternion& rotation, const Vector3& scale) noexcept;
+    [[nodiscard]] static inline TQS CreateInverse(const Vector3& translation, const Quaternion& rotation, const Vector3& scale) noexcept;
+
+public:
+    [[nodiscard]] inline TQS Inverse() const noexcept;
+    [[nodiscard]] inline Vector3 MulPoint3(const Vector3& v, bool useScale = true) const noexcept;
+    [[nodiscard]] inline Vector3 MulVector3(const Vector3& v, bool useScale = true) const noexcept;
+
+    [[nodiscard]] inline Vector3 InvMulPoint3(const Vector3& v, bool useScale = true) const noexcept;
+    [[nodiscard]] inline Vector3 InvMulVector3(const Vector3& v, bool useScale = true) const noexcept;
+
+    [[nodiscard]] static inline TQS Mul(const TQS& a, const TQS& b) noexcept;
+    [[nodiscard]] static inline TQS Blend(const TQS& a, const TQS& b, float t) noexcept;
+};
+
+
+TQS::TQS() noexcept :
+    t(Vector3::Zero),
+    q(Quaternion::Identity),
+    s(Vector3::One)
+{
+}
+
+TQS::TQS(const Vector3& translation, const Quaternion& rotation, const Vector3& scale) noexcept :
+    t(translation),
+    q(rotation),
+    s(scale)
+{
+}
+
+TQS TQS::CreateIdentity() noexcept
+{
+    return TQS{};
+}
+
+TQS TQS::Create(const Vector3& translation, const Quaternion& rotation, const Vector3& scale) noexcept
+{
+    return TQS{translation, rotation, scale};
+}
+
+TQS TQS::CreateInverse(const Vector3& translation, const Quaternion& rotation, const Vector3& scale) noexcept
+{
+    using namespace rtm;
+    qvvf qvvInv = qvv_inverse(qvv_set(rotation, translation, scale));
+    return TQS{static_cast<Vector3>(qvvInv.translation),
+               static_cast<Quaternion>(qvvInv.rotation),
+               static_cast<Vector3>(qvvInv.scale)};
+}
+
+Matrix4x4 TQS::ToMatrix4x4() const noexcept
+{
+    return Matrix4x4::FromTRS(t, q, s);
+}
+
+Matrix4x4 TQS::ToMatrix4x4Inverse() const noexcept
+{
+    using namespace rtm;
+    qvvf qvvInv = qvv_inverse(qvv_set(q, t, s));
+    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, matrix_from_qvv(qvvInv));
+}
+
+TQS TQS::Inverse() const noexcept
+{
+    using namespace rtm;
+    qvvf qvvInv = qvv_inverse(qvv_set(q, t, s));
+    return TQS{static_cast<Vector3>(qvvInv.translation),
+               static_cast<Quaternion>(qvvInv.rotation),
+               static_cast<Vector3>(qvvInv.scale)};
+}
+
+Vector3 TQS::MulPoint3(const Vector3& v, bool useScale) const noexcept
+{
+    using namespace rtm;
+    auto vSIMD = static_cast<Vector3::SIMDValueType>(v);
+    qvvf qvv   = qvv_set(q, t, s);
+
+    return static_cast<Vector3>(useScale ?
+                                    qvv_mul_point3(vSIMD, qvv) :
+                                    qvv_mul_point3_no_scale(vSIMD, qvv));
+}
+
+Vector3 TQS::MulVector3(const Vector3& v, bool useScale) const noexcept
+{
+    using namespace rtm;
+    return MulPoint3(v, useScale) - t;
+}
+
+Vector3 TQS::InvMulPoint3(const Vector3& v, bool useScale) const noexcept
+{
+    using namespace rtm;
+    qvvf qvvInv = qvv_inverse(qvv_set(q, t, s));
+    auto vSIMD  = static_cast<Vector3::SIMDValueType>(v);
+    return static_cast<Vector3>(useScale ?
+                                    qvv_mul_point3(vSIMD, qvvInv) :
+                                    qvv_mul_point3_no_scale(vSIMD, qvvInv));
+}
+
+Vector3 TQS::InvMulVector3(const Vector3& v, bool useScale) const noexcept
+{
+    using namespace rtm;
+    return InvMulPoint3(v, useScale) - t;
+}
+
+
+TQS TQS::Mul(const TQS& a, const TQS& b) noexcept
+{
+    using namespace rtm;
+    qvvf qvvA = qvv_set(a.q, a.t, a.s);
+    qvvf qvvB = qvv_set(b.q, b.t, b.s);
+    qvvf qvv  = qvv_mul(qvvA, qvvB);
+
+    return TQS{static_cast<Vector3>(qvv.translation),
+               static_cast<Quaternion>(qvv.rotation),
+               static_cast<Vector3>(qvv.scale)};
+}
+
+TQS TQS::Blend(const TQS& a, const TQS& b, float t) noexcept
+{
+    using namespace rtm;
+    qvvf qvvA = qvv_set(a.q, a.t, a.s);
+    qvvf qvvB = qvv_set(b.q, b.t, b.s);
+    qvvf qvv  = qvv_slerp(qvvA, qvvB, t);
+
+    return TQS{static_cast<Vector3>(qvv.translation),
+               static_cast<Quaternion>(qvv.rotation),
+               static_cast<Vector3>(qvv.scale)};
+}
+
+} // namespace gore

--- a/src/Math/TQS.h
+++ b/src/Math/TQS.h
@@ -68,12 +68,6 @@ TQS::TQS(const Vector3& translation, const Quaternion& rotation, const Vector3& 
 {
 }
 
-std::ostream& operator<<(std::ostream& os, const TQS& tqs) noexcept
-{
-    os << "TQS(" << tqs.t << ", " << tqs.q << ", " << tqs.s << ")";
-    return os;
-}
-
 TQS::operator SIMDValueType() const noexcept
 {
     return rtm::qvv_set(q, t, s);

--- a/src/Math/Vector3.cpp
+++ b/src/Math/Vector3.cpp
@@ -14,31 +14,6 @@ std::ostream& operator<<(std::ostream& os, const Vector3& v) noexcept
     return os << "Vector3(" << v.x << ", " << v.y << ", " << v.z << ")";
 }
 
-Vector3::operator SIMDValueType() const noexcept
-{
-    return vector_load3((reinterpret_cast<const float*>(this)));
-}
-
-Vector3::Vector3(const Vector3::SIMDValueType& F) noexcept :
-    x(rtm::vector_get_x(F)),
-    y(rtm::vector_get_y(F)),
-    z(rtm::vector_get_z(F))
-{
-}
-
-Vector3::Vector3(Vector3::SIMDValueType&& F) noexcept :
-    x(rtm::vector_get_x(std::move(F))),
-    y(rtm::vector_get_y(std::move(F))),
-    z(rtm::vector_get_z(std::move(F)))
-{
-}
-
-Vector3& Vector3::operator=(const Vector3::SIMDValueType& F) noexcept
-{
-    rtm::vector_store3(F, reinterpret_cast<float*>(this));
-    return *this;
-}
-
 Vector4 Vector3::AsPoint() const noexcept
 {
     return Vector4(x, y, z, 1.0f);

--- a/src/Math/Vector3.inl
+++ b/src/Math/Vector3.inl
@@ -1,5 +1,32 @@
 #pragma once
 
+// Conversion with SIMDValueType
+Vector3::operator SIMDValueType() const noexcept
+{
+    using namespace rtm;
+    return vector_load3((reinterpret_cast<const float*>(this)));
+}
+
+Vector3::Vector3(const Vector3::SIMDValueType& F) noexcept :
+    x(rtm::vector_get_x(F)),
+    y(rtm::vector_get_y(F)),
+    z(rtm::vector_get_z(F))
+{
+}
+
+Vector3::Vector3(Vector3::SIMDValueType&& F) noexcept :
+    x(rtm::vector_get_x(std::move(F))),
+    y(rtm::vector_get_y(std::move(F))),
+    z(rtm::vector_get_z(std::move(F)))
+{
+}
+
+Vector3& Vector3::operator=(const Vector3::SIMDValueType& F) noexcept
+{
+    rtm::vector_store3(F, reinterpret_cast<float*>(this));
+    return *this;
+}
+
 //------------------------------------------------------------------------------
 // Comparison operators
 //------------------------------------------------------------------------------

--- a/src/Math/Vector4.cpp
+++ b/src/Math/Vector4.cpp
@@ -12,9 +12,4 @@ std::ostream& operator<<(std::ostream& os, const Vector4& v) noexcept
     return os << "Vector4(" << v.x << ", " << v.y << ", " << v.z << ", " << v.w << ")";
 }
 
-Vector4::operator SIMDValueType() const noexcept
-{
-    return vector_load((reinterpret_cast<const float*>(this)));
-}
-
 } // namespace gore

--- a/src/Math/Vector4.h
+++ b/src/Math/Vector4.h
@@ -95,4 +95,6 @@ public:
 
 MATHF_VECTOR_BINARY_OPERATOR_DECLARATIONS(Vector4);
 
+#include "Vector4.inl"
+
 } // namespace gore

--- a/src/Math/Vector4.inl
+++ b/src/Math/Vector4.inl
@@ -1,0 +1,4 @@
+Vector4::operator SIMDValueType() const noexcept
+{
+    return rtm::vector_load((reinterpret_cast<const float*>(this)));
+}

--- a/src/Object/Camera.cpp
+++ b/src/Object/Camera.cpp
@@ -44,7 +44,7 @@ Matrix4x4 Camera::GetViewMatrix() const
 {
     // 1. A camera is always attached to a game object, so we can safely assume that the transform is not null
     // 2. A camera never cares about the scale of the transform, so we can safely ignore it
-    return m_GameObject->transform->GetWorldToLocalMatrixIgnoreScale();
+    return m_GameObject->GetTransform()->GetWorldToLocalMatrixIgnoreScale();
 }
 
 Matrix4x4 Camera::GetViewProjectionMatrix() const

--- a/src/Object/Component.h
+++ b/src/Object/Component.h
@@ -46,3 +46,9 @@ protected:
 };
 
 } // namespace gore
+
+#define DECLARE_FUNCTIONS_DERIVED_FROM_GORE_COMPONENT(CLASS_NAME) \
+    explicit CLASS_NAME(gore::GameObject* gameObject);            \
+    ~CLASS_NAME() override;                                       \
+    void Start() override;                                        \
+    void Update() override;

--- a/src/Object/Component.h
+++ b/src/Object/Component.h
@@ -48,7 +48,7 @@ protected:
 } // namespace gore
 
 #define DECLARE_FUNCTIONS_DERIVED_FROM_GORE_COMPONENT(CLASS_NAME) \
-    explicit CLASS_NAME(gore::GameObject* gameObject);            \
+    explicit CLASS_NAME(::gore::GameObject* gameObject);            \
     ~CLASS_NAME() override;                                       \
     void Start() override;                                        \
     void Update() override;

--- a/src/Object/GameObject.cpp
+++ b/src/Object/GameObject.cpp
@@ -38,10 +38,6 @@ void GameObject::Update()
         component->Update();
     }
 }
-void GameObject::Destroy()
-{
-    m_Scene->DestroyObject(this);
-}
 
 template <>
 Component::SelfOrDerivedTypePointer<Transform> GameObject::AddComponent<Transform>()

--- a/src/Object/GameObject.cpp
+++ b/src/Object/GameObject.cpp
@@ -38,6 +38,10 @@ void GameObject::Update()
         component->Update();
     }
 }
+void GameObject::Destroy()
+{
+    m_Scene->DestroyObject(this);
+}
 
 template <>
 Component::SelfOrDerivedTypePointer<Transform> GameObject::AddComponent<Transform>()

--- a/src/Object/GameObject.cpp
+++ b/src/Object/GameObject.cpp
@@ -13,11 +13,11 @@ namespace gore
 GameObject::GameObject(std::string name, Scene* scene) :
     Object(std::move(name)),
     m_Scene(scene),
-    transform(),
+    m_Transform(),
     m_Components()
 {
     AddComponent<Transform>();
-    transform = reinterpret_cast<Transform*>(m_Components[0]);
+    m_Transform = reinterpret_cast<Transform*>(m_Components[0]);
 }
 
 GameObject::~GameObject()
@@ -42,11 +42,11 @@ void GameObject::Update()
 template <>
 Component::SelfOrDerivedTypePointer<Transform> GameObject::AddComponent<Transform>()
 {
-    if (transform != nullptr)
+    if (m_Transform != nullptr)
     {
         LOG_STREAM(ERROR) << "Cannot add more than one Transform component to GameObject. "
                           << "This operation will do nothing." << std::endl;
-        return const_cast<Transform*>(transform);
+        return m_Transform;
     }
 
     auto pTransform = new Transform(this);
@@ -56,11 +56,11 @@ Component::SelfOrDerivedTypePointer<Transform> GameObject::AddComponent<Transfor
 template <>
 Component::SelfOrDerivedTypePointer<Transform> GameObject::AddComponent(Transform* inpTransform)
 {
-    if (transform != nullptr)
+    if (m_Transform != nullptr)
     {
         LOG_STREAM(ERROR) << "Cannot add more than one Transform component to GameObject. "
                           << "This operation will do nothing." << std::endl;
-        return const_cast<Transform*>(transform);
+        return m_Transform;
     }
 
     m_Components.push_back(inpTransform);

--- a/src/Object/GameObject.h
+++ b/src/Object/GameObject.h
@@ -27,6 +27,11 @@ public:
         return m_Scene;
     }
 
+    [[nodiscard]] Transform* GetTransform() const
+    {
+        return m_Transform;
+    }
+
 public:
     template <typename T>
     Component::SelfOrDerivedTypePointer<T> AddComponent();
@@ -61,10 +66,8 @@ private:
 
     Scene* m_Scene;
 
+    Transform* m_Transform;
     std::vector<Component*> m_Components;
-
-public:
-    Transform* transform;
 };
 
 #if COMPILER_GCC

--- a/src/Object/GameObject.h
+++ b/src/Object/GameObject.h
@@ -32,6 +32,9 @@ public:
         return m_Transform;
     }
 
+    // Note that this is a "delete this" operation. Use it carefully.
+    void Destroy();
+
 public:
     template <typename T>
     Component::SelfOrDerivedTypePointer<T> AddComponent();

--- a/src/Object/GameObject.h
+++ b/src/Object/GameObject.h
@@ -32,8 +32,6 @@ public:
         return m_Transform;
     }
 
-    void Destroy();
-
 public:
     template <typename T>
     Component::SelfOrDerivedTypePointer<T> AddComponent();

--- a/src/Object/GameObject.h
+++ b/src/Object/GameObject.h
@@ -32,6 +32,8 @@ public:
         return m_Transform;
     }
 
+    void Destroy();
+
 public:
     template <typename T>
     Component::SelfOrDerivedTypePointer<T> AddComponent();

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -132,7 +132,7 @@ void Transform::SetParent(Transform* newParent, bool reCalculateLocalTQS /* = tr
 
     if (reCalculateLocalTQS)
     {
-        m_LocalTQS = newParent == nullptr ? this->m_LocalTQS : TQS::Mul(this->GetLocalToWorldTQS(), newParent->GetWorldToLocalTQS());
+        m_LocalTQS = newParent == nullptr ? this->GetLocalToWorldTQS() : TQS::Mul(this->GetLocalToWorldTQS(), newParent->GetWorldToLocalTQS());
     }
 
     m_Parent = newParent;

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -36,6 +36,14 @@ void Transform::Update()
 //    return m_LocalRotation.ToEuler();
 //}
 
+Transform* Transform::GetRoot() const
+{
+    auto pTransform = const_cast<Transform*>(this);
+    while (pTransform->m_Parent != nullptr)
+        pTransform = pTransform->m_Parent;
+    return pTransform;
+}
+
 void Transform::RotateAroundAxis(const Vector3& axis, float angle)
 {
     m_LocalTQS.q = Quaternion::CreateFromAxisAngle(axis, angle) * m_LocalTQS.q;
@@ -59,6 +67,67 @@ Matrix4x4 Transform::GetWorldToLocalMatrix() const
 Matrix4x4 Transform::GetWorldToLocalMatrixIgnoreScale() const
 {
     return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qv(rtm::qv_inverse(rtm::qvf{.rotation = m_LocalTQS.q, .translation = m_LocalTQS.t})));
+}
+
+void Transform::SetParent(Transform* newParent, bool reCalculateLocalTQS /* = true */)
+{
+    if (m_Parent == newParent)
+        return;
+
+    auto oldParent = m_Parent;
+
+    if (newParent != nullptr)
+    {
+        // check if newParent is a child of this
+        auto it = std::find(newParent->begin(), newParent->end(), this);
+        if (it != newParent->m_Children.end())
+        {
+            LOG_STREAM(ERROR) << "Cannot set parent to a child of this Transform. "
+                              << "This operation will do nothing." << std::endl;
+            return;
+        }
+    }
+
+    if (oldParent != nullptr)
+    {
+        auto it = std::find(m_Parent->begin(), m_Parent->end(), this);
+        if (it != m_Parent->m_Children.end())
+            m_Parent->m_Children.erase(it);
+    }
+    if (newParent != nullptr)
+    {
+        newParent->m_Children.push_back(this);
+    }
+
+    if (reCalculateLocalTQS)
+    {
+        m_LocalTQS = newParent == nullptr ? this->m_LocalTQS : TQS::Mul(this->GetLocalToWorldTQS(), newParent->GetWorldToLocalTQS());
+    }
+
+    m_Parent = newParent;
+}
+
+TQS Transform::GetLocalToWorldTQS() const
+{
+    if (m_Parent == nullptr)
+    {
+        return m_LocalTQS;
+    }
+
+    const Transform* current = m_Parent;
+    TQS result               = m_LocalTQS;
+
+    while (current != nullptr)
+    {
+        result  = TQS::Mul(result, current->m_LocalTQS);
+        current = current->m_Parent;
+    }
+    return result;
+}
+
+TQS Transform::GetWorldToLocalTQS() const
+{
+    return GetLocalToWorldTQS().Inverse();
 }
 
 } // namespace gore

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -13,8 +13,8 @@ namespace gore
 Transform::~Transform()
 {
     LOG_STREAM(WARNING) << "Destroyed Transform in GameObject " << GetGameObject()->GetName()
-        << ". Note that the destruction of children objects has NOT been implemented."
-        << std::endl;
+                        << ". Note that the destruction of children objects has NOT been implemented."
+                        << std::endl;
 }
 
 void Transform::SetLocalEulerAngles(const Vector3& eulerAngles)
@@ -137,6 +137,26 @@ TQS Transform::GetLocalToWorldTQS() const
 TQS Transform::GetWorldToLocalTQS() const
 {
     return GetLocalToWorldTQS().Inverse();
+}
+
+Vector3 Transform::TransformPoint(const Vector3& point, bool useScale /* = true */) const
+{
+    return GetLocalToWorldTQS().MulPoint3(point, useScale);
+}
+
+Vector3 Transform::TransformVector3(const Vector3& vector, bool useScale /* = true */) const
+{
+    return GetLocalToWorldTQS().MulVector3(vector, useScale);
+}
+
+Vector3 Transform::InverseTransformPoint(const Vector3& point, bool useScale /* = true */) const
+{
+    return GetWorldToLocalTQS().InvMulPoint3(point, useScale);
+}
+
+Vector3 Transform::InverseTransformVector3(const Vector3& vector, bool useScale /* = true */) const
+{
+    return GetWorldToLocalTQS().InvMulVector3(vector, useScale);
 }
 
 } // namespace gore

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -78,7 +78,7 @@ bool Transform::IsChildOf(const Transform* parent, bool recursive /* = false */)
 
 bool Transform::IsParentOf(const Transform* child, bool recursive /* = false */) const
 {
-    return child->IsChildOf(this, true);
+    return child->IsChildOf(this, recursive);
 }
 
 

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -10,24 +10,9 @@
 namespace gore
 {
 
-void Transform::SetLocalPosition(const Vector3& position)
-{
-    this->m_LocalPosition = position;
-}
-
-void Transform::SetLocalScale(const Vector3& scale)
-{
-    this->m_LocalScale = scale;
-}
-
-void Transform::SetLocalRotation(const Quaternion& rotation)
-{
-    this->m_LocalRotation = rotation;
-}
-
 void Transform::SetLocalEulerAngles(const Vector3& eulerAngles)
 {
-    m_LocalRotation = Quaternion::CreateFromYawPitchRoll(eulerAngles.y, eulerAngles.x, eulerAngles.z);
+    m_LocalTQS.q = Quaternion::CreateFromYawPitchRoll(eulerAngles.y, eulerAngles.x, eulerAngles.z);
 }
 
 void Transform::Start()
@@ -44,20 +29,6 @@ void Transform::Update()
     //                   << "  Scale: " << m_LocalScale << std::endl;
 }
 
-Vector3 Transform::GetLocalPosition() const
-{
-    return m_LocalPosition;
-}
-
-Vector3 Transform::GetLocalScale() const
-{
-    return m_LocalScale;
-}
-
-Quaternion Transform::GetLocalRotation() const
-{
-    return m_LocalRotation;
-}
 
 // Quaternion.ToEuler() has not been implemented
 // Vector3 Transform::GetLocalEulerAngles() const
@@ -67,27 +38,27 @@ Quaternion Transform::GetLocalRotation() const
 
 void Transform::RotateAroundAxis(const Vector3& axis, float angle)
 {
-    m_LocalRotation = Quaternion::CreateFromAxisAngle(axis, angle) * m_LocalRotation;
+    m_LocalTQS.q = Quaternion::CreateFromAxisAngle(axis, angle) * m_LocalTQS.q;
 }
 
 Matrix4x4 Transform::GetLocalToWorldMatrix() const
 {
-    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qvv(m_LocalRotation, m_LocalPosition, m_LocalScale));
+    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qvv(m_LocalTQS.q, m_LocalTQS.t, m_LocalTQS.s));
 }
 
 Matrix4x4 Transform::GetLocalToWorldMatrixIgnoreScale() const
 {
-    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qv(m_LocalRotation, m_LocalPosition));
+    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qv(m_LocalTQS.q, m_LocalTQS.t));
 }
 
 Matrix4x4 Transform::GetWorldToLocalMatrix() const
 {
-    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qvv(rtm::qvv_inverse(rtm::qvvf{.rotation = m_LocalRotation, .translation = m_LocalPosition, .scale = m_LocalScale})));
+    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qvv(rtm::qvv_inverse(rtm::qvvf{.rotation = m_LocalTQS.q, .translation = m_LocalTQS.t, .scale = m_LocalTQS.s})));
 }
 
 Matrix4x4 Transform::GetWorldToLocalMatrixIgnoreScale() const
 {
-    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qv(rtm::qv_inverse(rtm::qvf{.rotation = m_LocalRotation, .translation = m_LocalPosition})));
+    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qv(rtm::qv_inverse(rtm::qvf{.rotation = m_LocalTQS.q, .translation = m_LocalTQS.t})));
 }
 
 } // namespace gore

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -51,6 +51,28 @@ Transform* Transform::GetRoot() const
     return pTransform;
 }
 
+Transform* Transform::Find(const std::string& name, bool recursive) const
+{
+    auto result = std::find_if(m_Children.begin(), m_Children.end(), [name](Transform* child)
+                               { return child->GetGameObject()->GetName() == name; });
+    if (result != m_Children.end())
+    {
+        return *result;
+    }
+    if (!recursive)
+    {
+        return nullptr;
+    }
+
+    for (auto& child : m_Children)
+    {
+        auto pTransform = child->Find(name, recursive);
+        if (pTransform != nullptr)
+            return pTransform;
+    }
+    return nullptr;
+}
+
 void Transform::RotateAroundAxis(const Vector3& axis, float angle)
 {
     m_LocalTQS.q = Quaternion::CreateFromAxisAngle(axis, angle) * m_LocalTQS.q;

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -222,12 +222,12 @@ Vector3 Transform::TransformVector3(const Vector3& vector, bool useScale /* = tr
 
 Vector3 Transform::InverseTransformPoint(const Vector3& point, bool useScale /* = true */) const
 {
-    return GetWorldToLocalTQS().InvMulPoint3(point, useScale);
+    return GetLocalToWorldTQS().InvMulPoint3(point, useScale);
 }
 
 Vector3 Transform::InverseTransformVector3(const Vector3& vector, bool useScale /* = true */) const
 {
-    return GetWorldToLocalTQS().InvMulVector3(vector, useScale);
+    return GetLocalToWorldTQS().InvMulVector3(vector, useScale);
 }
 
 } // namespace gore

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -54,21 +54,31 @@ Transform* Transform::GetRoot() const
     return pTransform;
 }
 
-bool Transform::IsChildOf(const Transform* parent) const
+bool Transform::IsChildOf(const Transform* parent, bool recursive /* = false */) const
 {
-    auto pTransform = const_cast<Transform*>(this);
-    while (pTransform->m_Parent != nullptr)
+    if (parent == nullptr)
     {
-        if (pTransform->m_Parent == parent)
+        LOG_STREAM(ERROR) << "Cannot check if this Transform is a child of a nullptr. "
+                          << "This operation will return false." << std::endl;
+        return false;
+    }
+
+    auto pTransform = const_cast<Transform*>(this);
+    if (!recursive)
+    {
+        return pTransform->m_Parent == parent;
+    }
+    while ((pTransform = pTransform->m_Parent) != nullptr)
+    {
+        if (pTransform == parent)
             return true;
-        pTransform = pTransform->m_Parent;
     }
     return false;
 }
 
-bool Transform::IsParentOf(const Transform* child) const
+bool Transform::IsParentOf(const Transform* child, bool recursive /* = false */) const
 {
-    return child->IsChildOf(this);
+    return child->IsChildOf(this, true);
 }
 
 

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -54,6 +54,24 @@ Transform* Transform::GetRoot() const
     return pTransform;
 }
 
+bool Transform::IsChildOf(const Transform* parent) const
+{
+    auto pTransform = const_cast<Transform*>(this);
+    while (pTransform->m_Parent != nullptr)
+    {
+        if (pTransform->m_Parent == parent)
+            return true;
+        pTransform = pTransform->m_Parent;
+    }
+    return false;
+}
+
+bool Transform::IsParentOf(const Transform* child) const
+{
+    return child->IsChildOf(this);
+}
+
+
 Transform* Transform::Find(const std::string& name, bool recursive) const
 {
     auto result = std::find_if(m_Children.begin(), m_Children.end(), [name](Transform* child)
@@ -158,17 +176,12 @@ void Transform::SetParent(Transform* newParent, bool reCalculateLocalTQS /* = tr
         return;
 
     auto oldParent = m_Parent;
-
-    if (newParent != nullptr)
+    
+    if (newParent->IsChildOf(this))
     {
-        // check if newParent is a child of this
-        auto it = std::find(newParent->begin(), newParent->end(), this);
-        if (it != newParent->m_Children.end())
-        {
-            LOG_STREAM(ERROR) << "Cannot set parent to a child of this Transform. "
-                              << "This operation will do nothing." << std::endl;
-            return;
-        }
+        LOG_STREAM(ERROR) << "Cannot set parent to a child of this Transform. "
+                          << "This operation will do nothing." << std::endl;
+        return;
     }
 
     if (oldParent != nullptr)

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -73,6 +73,55 @@ Transform* Transform::Find(const std::string& name, bool recursive) const
     return nullptr;
 }
 
+Vector3 Transform::GetWorldPosition() const
+{
+    return GetLocalToWorldTQS().t;
+}
+
+void Transform::SetWorldPosition(const Vector3& position)
+{
+    if (m_Parent == nullptr)
+    {
+        m_LocalTQS.t = position;
+        return;
+    }
+
+    m_LocalTQS.t = m_Parent->InverseTransformPoint(position);
+}
+
+Vector3 Transform::GetWorldScale() const
+{
+    return GetLocalToWorldTQS().s;
+}
+
+void Transform::SetWorldScale(const Vector3& scale)
+{
+    if (m_Parent == nullptr)
+    {
+        m_LocalTQS.s = scale;
+        return;
+    }
+
+    m_LocalTQS.s = m_Parent->InverseTransformVector3(scale);
+}
+
+Quaternion Transform::GetWorldRotation() const
+{
+    return GetLocalToWorldTQS().q;
+}
+
+void Transform::SetWorldRotation(const Quaternion& rotation)
+{
+    if (m_Parent == nullptr)
+    {
+        m_LocalTQS.q = rotation;
+        return;
+    }
+
+    auto parentRotation = m_Parent->GetWorldRotation();
+    m_LocalTQS.q        = parentRotation.Inverse() * rotation;
+}
+
 void Transform::RotateAroundAxis(const Vector3& axis, float angle)
 {
     m_LocalTQS.q = Quaternion::CreateFromAxisAngle(axis, angle) * m_LocalTQS.q;

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -10,6 +10,13 @@
 namespace gore
 {
 
+Transform::~Transform()
+{
+    LOG_STREAM(WARNING) << "Destroyed Transform in GameObject " << GetGameObject()->GetName()
+        << ". Note that the destruction of children objects has NOT been implemented."
+        << std::endl;
+}
+
 void Transform::SetLocalEulerAngles(const Vector3& eulerAngles)
 {
     m_LocalTQS.q = Quaternion::CreateFromYawPitchRoll(eulerAngles.y, eulerAngles.x, eulerAngles.z);

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -19,7 +19,7 @@ Transform::~Transform()
 
 void Transform::SetLocalEulerAngles(const Vector3& eulerAngles)
 {
-    m_LocalTQS.q = Quaternion::CreateFromYawPitchRoll(eulerAngles.y, eulerAngles.x, eulerAngles.z);
+    m_LocalTQS.q = Quaternion::FromYawPitchRoll(eulerAngles.y, eulerAngles.x, eulerAngles.z);
 }
 
 void Transform::Start()
@@ -124,7 +124,7 @@ void Transform::SetWorldRotation(const Quaternion& rotation)
 
 void Transform::RotateAroundAxis(const Vector3& axis, float angle)
 {
-    m_LocalTQS.q = Quaternion::CreateFromAxisAngle(axis, angle) * m_LocalTQS.q;
+    m_LocalTQS.q = Quaternion::FromAxisAngle(axis, angle) * m_LocalTQS.q;
 }
 
 Matrix4x4 Transform::GetLocalToWorldMatrix() const

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -51,22 +51,24 @@ void Transform::RotateAroundAxis(const Vector3& axis, float angle)
 
 Matrix4x4 Transform::GetLocalToWorldMatrix() const
 {
-    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qvv(m_LocalTQS.q, m_LocalTQS.t, m_LocalTQS.s));
+    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qvv(static_cast<TQS::SIMDValueType>(GetLocalToWorldTQS())));
 }
 
 Matrix4x4 Transform::GetLocalToWorldMatrixIgnoreScale() const
 {
-    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qv(m_LocalTQS.q, m_LocalTQS.t));
+    TQS tqsWorld = GetLocalToWorldTQS();
+    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qv(tqsWorld.q, tqsWorld.t));
 }
 
 Matrix4x4 Transform::GetWorldToLocalMatrix() const
 {
-    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qvv(rtm::qvv_inverse(rtm::qvvf{.rotation = m_LocalTQS.q, .translation = m_LocalTQS.t, .scale = m_LocalTQS.s})));
+    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qvv(static_cast<TQS::SIMDValueType>(GetWorldToLocalTQS())));
 }
 
 Matrix4x4 Transform::GetWorldToLocalMatrixIgnoreScale() const
 {
-    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qv(rtm::qv_inverse(rtm::qvf{.rotation = m_LocalTQS.q, .translation = m_LocalTQS.t})));
+    TQS tqsWorld = GetLocalToWorldTQS();
+    return CAST_FROM_SIMD_MATRIX_HELPER(Matrix4x4, rtm::matrix_from_qv(rtm::qv_inverse(rtm::qv_set(tqsWorld.q, tqsWorld.t))));
 }
 
 void Transform::SetParent(Transform* newParent, bool reCalculateLocalTQS /* = true */)

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -10,6 +10,14 @@
 namespace gore
 {
 
+Transform::Transform(gore::GameObject* gameObject) :
+    Component(gameObject),
+    m_LocalTQS(),
+    m_Parent(nullptr),
+    m_Children()
+{
+}
+
 Transform::~Transform() = default;
 
 void Transform::SetLocalEulerAngles(const Vector3& eulerAngles)

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -213,6 +213,23 @@ void Transform::SetParent(Transform* newParent, bool reCalculateLocalTQS /* = tr
     m_Parent = newParent;
 }
 
+int Transform::GetSiblingIndex() const
+{
+    if (m_Parent == nullptr)
+    {
+        return 0;
+    }
+
+    auto it = std::find(m_Parent->begin(), m_Parent->end(), this);
+    if (it == m_Parent->end())
+    {
+        LOG_STREAM(ERROR) << "Cannot find this Transform in its parent's children. "
+                          << "This operation will return 0." << std::endl;
+        return 0;
+    }
+    return static_cast<int>(std::distance(m_Parent->m_Children.begin(), it));
+}
+
 TQS Transform::GetLocalToWorldTQS() const
 {
     if (m_Parent == nullptr)

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -187,7 +187,7 @@ void Transform::SetParent(Transform* newParent, bool reCalculateLocalTQS /* = tr
 
     auto oldParent = m_Parent;
     
-    if (newParent->IsChildOf(this))
+    if (newParent != nullptr && newParent->IsChildOf(this, true))
     {
         LOG_STREAM(ERROR) << "Cannot set parent to a child of this Transform. "
                           << "This operation will do nothing." << std::endl;

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -10,12 +10,7 @@
 namespace gore
 {
 
-Transform::~Transform()
-{
-    LOG_STREAM(WARNING) << "Destroyed Transform in GameObject " << GetGameObject()->GetName()
-                        << ". Note that the destruction of children objects has NOT been implemented."
-                        << std::endl;
-}
+Transform::~Transform() = default;
 
 void Transform::SetLocalEulerAngles(const Vector3& eulerAngles)
 {

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -119,7 +119,7 @@ void Transform::SetWorldRotation(const Quaternion& rotation)
     }
 
     auto parentRotation = m_Parent->GetWorldRotation();
-    m_LocalTQS.q        = parentRotation.Inverse() * rotation;
+    m_LocalTQS.q        = rotation * parentRotation.Inverse();
 }
 
 void Transform::RotateAroundAxis(const Vector3& axis, float angle)

--- a/src/Object/Transform.cpp
+++ b/src/Object/Transform.cpp
@@ -58,9 +58,16 @@ bool Transform::IsChildOf(const Transform* parent, bool recursive /* = false */)
 {
     if (parent == nullptr)
     {
-        LOG_STREAM(ERROR) << "Cannot check if this Transform is a child of a nullptr. "
-                          << "This operation will return false." << std::endl;
-        return false;
+        if (recursive)
+        {
+            LOG_STREAM(WARNING) << "Ultimately each object's very last parent is nullptr, i.e. root transform's parent. "
+                                << "This operation will always return true. "
+                                << "Please double check if you really want this" << std::endl;
+            return true;
+        }
+        LOG_STREAM(WARNING) << "IsChildOf(nullptr, false) is effectively the same as IsRootTransform() but with more value checks."
+                            << "Please use IsRootTransform() instead." << std::endl;
+        return m_Parent == nullptr;
     }
 
     auto pTransform = const_cast<Transform*>(this);

--- a/src/Object/Transform.h
+++ b/src/Object/Transform.h
@@ -29,6 +29,7 @@ public:
 
     [[nodiscard]] Transform* GetChild(int index) const { return m_Children[index]; }
     [[nodiscard]] int GetChildCount() const { return static_cast<int>(m_Children.size()); }
+    [[nodiscard]] int GetSiblingIndex() const;
 
     // iterator
     [[nodiscard]] auto begin() { return m_Children.begin(); }

--- a/src/Object/Transform.h
+++ b/src/Object/Transform.h
@@ -78,11 +78,11 @@ public:
     void RotateAroundAxis(const Vector3& axis, float angle);
     void RotateAroundPointInWorldSpace(const Vector3& pointInWorldSpace, const Vector3& axisInWorldSpace, float angle);
 
-    Vector3 TransformPoint(const Vector3& point) const;
-    Vector3 TransformVector3(const Vector3& direction) const;
+    [[nodiscard]] Vector3 TransformPoint(const Vector3& point, bool useScale = true) const;
+    [[nodiscard]] Vector3 TransformVector3(const Vector3& vector, bool useScale = true) const;
 
-    Vector3 InverseTransformPoint(const Vector3& point) const;
-    Vector3 InverseTransformVector3(const Vector3& vector, bool useScale = true) const;
+    [[nodiscard]] Vector3 InverseTransformPoint(const Vector3& point, bool useScale = true) const;
+    [[nodiscard]] Vector3 InverseTransformVector3(const Vector3& vector, bool useScale = true) const;
 
     [[nodiscard]] Matrix4x4 GetLocalToWorldMatrix() const;
     [[nodiscard]] Matrix4x4 GetLocalToWorldMatrixIgnoreScale() const;

--- a/src/Object/Transform.h
+++ b/src/Object/Transform.h
@@ -44,6 +44,8 @@ public:
     // clang-format on
 
     [[nodiscard]] Transform* GetRoot() const;
+    [[nodiscard]] bool IsChildOf(const Transform* parent) const;
+    [[nodiscard]] bool IsParentOf(const Transform* child) const;
 
     [[nodiscard]] Transform* Find(const std::string& name, bool recursive = false) const;
 

--- a/src/Object/Transform.h
+++ b/src/Object/Transform.h
@@ -75,6 +75,18 @@ public:
     [[nodiscard]] Vector3 GetLocalEulerAngles() const;
     void SetLocalEulerAngles(const Vector3& eulerAngles);
 
+    [[nodiscard]] Vector3 GetWorldPosition() const;
+    void SetWorldPosition(const Vector3& position);
+
+    [[nodiscard]] Vector3 GetWorldScale() const;
+    void SetWorldScale(const Vector3& scale);
+
+    [[nodiscard]] Quaternion GetWorldRotation() const;
+    void SetWorldRotation(const Quaternion& rotation);
+
+    [[nodiscard]] Vector3 GetWorldEulerAngles() const;
+    void SetWorldEulerAngles(const Vector3& eulerAngles);
+
     void RotateAroundAxis(const Vector3& axis, float angle);
     void RotateAroundPointInWorldSpace(const Vector3& pointInWorldSpace, const Vector3& axisInWorldSpace, float angle);
 

--- a/src/Object/Transform.h
+++ b/src/Object/Transform.h
@@ -37,7 +37,7 @@ public:
     // clang-format off
     // Hierarchy
     [[nodiscard]] Transform* GetParent() const { return m_Parent; }
-    void SetParent(Transform* parent);
+    void SetParent(Transform* newParent, bool reCalculateLocalTQS = true);
 
     [[nodiscard]] Transform* GetChild(int index) const { return m_Children[index]; }
     [[nodiscard]] int GetChildCount() const { return static_cast<int>(m_Children.size()); }
@@ -63,7 +63,6 @@ public:
     // clang-format off
     [[nodiscard]] Vector3 GetLocalPosition() const { return m_LocalTQS.t; }
     void SetLocalPosition(const Vector3& position) { m_LocalTQS.t = position; }
-    
 
     [[nodiscard]] Vector3 GetLocalScale() const { return m_LocalTQS.s; }
     void SetLocalScale(const Vector3& scale) { m_LocalTQS.s = scale; }
@@ -89,6 +88,9 @@ public:
 
     [[nodiscard]] Matrix4x4 GetWorldToLocalMatrix() const;
     [[nodiscard]] Matrix4x4 GetWorldToLocalMatrixIgnoreScale() const;
+
+    [[nodiscard]] TQS GetLocalToWorldTQS() const;
+    [[nodiscard]] TQS GetWorldToLocalTQS() const;
 
 private:
     Transform* m_Parent;

--- a/src/Object/Transform.h
+++ b/src/Object/Transform.h
@@ -28,10 +28,11 @@ public:
     {
     }
 
-    ~Transform() override = default;
-
     void Start() override;
     void Update() override;
+
+protected:
+    ~Transform() override;
 
 public:
     // clang-format off

--- a/src/Object/Transform.h
+++ b/src/Object/Transform.h
@@ -6,6 +6,8 @@
 #include "Core/Log.h"
 
 #include "Math/Types.h"
+#include "Math/TQS.h"
+
 #include <vector>
 #include <iterator>
 
@@ -20,9 +22,9 @@ public:
 
     explicit Transform(GameObject * gameObject) :
         Component(gameObject),
-        m_LocalPosition(Vector3::Zero),
-        m_LocalRotation(Quaternion::Identity),
-        m_LocalScale(Vector3::One)
+        m_Parent(nullptr),
+        m_Children(),
+        m_LocalTQS(TQS::CreateIdentity())
     {
     }
 
@@ -58,14 +60,18 @@ public:
     [[nodiscard]] Transform* Find(const std::string& name, bool recursive = false) const;
 
 public:
-    [[nodiscard]] Vector3 GetLocalPosition() const;
-    void SetLocalPosition(const Vector3& position);
+    // clang-format off
+    [[nodiscard]] Vector3 GetLocalPosition() const { return m_LocalTQS.t; }
+    void SetLocalPosition(const Vector3& position) { m_LocalTQS.t = position; }
+    
 
-    [[nodiscard]] Vector3 GetLocalScale() const;
-    void SetLocalScale(const Vector3& scale);
+    [[nodiscard]] Vector3 GetLocalScale() const { return m_LocalTQS.s; }
+    void SetLocalScale(const Vector3& scale) { m_LocalTQS.s = scale; }
 
-    [[nodiscard]] Quaternion GetLocalRotation() const;
-    void SetLocalRotation(const Quaternion& rotation);
+    [[nodiscard]] Quaternion GetLocalRotation() const { return m_LocalTQS.q; }
+    void SetLocalRotation(const Quaternion& rotation) { m_LocalTQS.q = rotation; }
+    // clang-format on
+
     [[nodiscard]] Vector3 GetLocalEulerAngles() const;
     void SetLocalEulerAngles(const Vector3& eulerAngles);
 
@@ -76,7 +82,7 @@ public:
     Vector3 TransformVector3(const Vector3& direction) const;
 
     Vector3 InverseTransformPoint(const Vector3& point) const;
-    Vector3 InverseTransformVector3(const Vector3& vector, bool affectedByScale = true) const;
+    Vector3 InverseTransformVector3(const Vector3& vector, bool useScale = true) const;
 
     [[nodiscard]] Matrix4x4 GetLocalToWorldMatrix() const;
     [[nodiscard]] Matrix4x4 GetLocalToWorldMatrixIgnoreScale() const;
@@ -88,9 +94,7 @@ private:
     Transform* m_Parent;
     std::vector<Transform*> m_Children;
 
-    Vector3 m_LocalPosition;
-    Quaternion m_LocalRotation;
-    Vector3 m_LocalScale;
+    TQS m_LocalTQS;
 };
 
 } // namespace gore

--- a/src/Object/Transform.h
+++ b/src/Object/Transform.h
@@ -19,20 +19,7 @@ ENGINE_CLASS(Transform) final : public Component
 {
 public:
     NON_COPYABLE(Transform);
-
-    explicit Transform(GameObject * gameObject) :
-        Component(gameObject),
-        m_Parent(nullptr),
-        m_Children(),
-        m_LocalTQS(TQS::CreateIdentity())
-    {
-    }
-
-    void Start() override;
-    void Update() override;
-
-protected:
-    ~Transform() override;
+    DECLARE_FUNCTIONS_DERIVED_FROM_GORE_COMPONENT(Transform);
 
 public:
     // clang-format off

--- a/src/Object/Transform.h
+++ b/src/Object/Transform.h
@@ -44,8 +44,8 @@ public:
     // clang-format on
 
     [[nodiscard]] Transform* GetRoot() const;
-    [[nodiscard]] bool IsChildOf(const Transform* parent) const;
-    [[nodiscard]] bool IsParentOf(const Transform* child) const;
+    [[nodiscard]] bool IsChildOf(const Transform* parent, bool recursive = false) const;
+    [[nodiscard]] bool IsParentOf(const Transform* child, bool recursive = false) const;
 
     [[nodiscard]] Transform* Find(const std::string& name, bool recursive = false) const;
 

--- a/src/Object/Transform.h
+++ b/src/Object/Transform.h
@@ -42,6 +42,8 @@ public:
     [[nodiscard]] auto rend() { return m_Children.rend(); }
     [[nodiscard]] auto rbegin() const { return m_Children.crbegin(); }
     [[nodiscard]] auto rend() const { return m_Children.crend(); }
+
+    [[nodiscard]] bool IsRootTransform() const { return m_Parent == nullptr;}
     // clang-format on
 
     [[nodiscard]] Transform* GetRoot() const;

--- a/src/Object/Transform.h
+++ b/src/Object/Transform.h
@@ -6,6 +6,9 @@
 #include "Core/Log.h"
 
 #include "Math/Types.h"
+#include <vector>
+#include <iterator>
+
 
 namespace gore
 {
@@ -15,17 +18,44 @@ ENGINE_CLASS(Transform) final : public Component
 public:
     NON_COPYABLE(Transform);
 
-    explicit Transform(GameObject* gameObject)
-        : Component(gameObject)
-        , m_LocalPosition(Vector3::Zero)
-        , m_LocalRotation(Quaternion::Identity)
-        , m_LocalScale(Vector3::One)
-    {}
+    explicit Transform(GameObject * gameObject) :
+        Component(gameObject),
+        m_LocalPosition(Vector3::Zero),
+        m_LocalRotation(Quaternion::Identity),
+        m_LocalScale(Vector3::One)
+    {
+    }
 
     ~Transform() override = default;
 
     void Start() override;
     void Update() override;
+
+public:
+    // clang-format off
+    // Hierarchy
+    [[nodiscard]] Transform* GetParent() const { return m_Parent; }
+    void SetParent(Transform* parent);
+
+    [[nodiscard]] Transform* GetChild(int index) const { return m_Children[index]; }
+    [[nodiscard]] int GetChildCount() const { return static_cast<int>(m_Children.size()); }
+
+    // iterator
+    [[nodiscard]] auto begin() { return m_Children.begin(); }
+    [[nodiscard]] auto end() { return m_Children.end(); }
+    [[nodiscard]] auto begin() const { return m_Children.cbegin(); }
+    [[nodiscard]] auto end() const { return m_Children.cend(); }
+
+    // reverse iterator
+    [[nodiscard]] auto rbegin() { return m_Children.rbegin(); }
+    [[nodiscard]] auto rend() { return m_Children.rend(); }
+    [[nodiscard]] auto rbegin() const { return m_Children.crbegin(); }
+    [[nodiscard]] auto rend() const { return m_Children.crend(); }
+    // clang-format on
+
+    [[nodiscard]] Transform* GetRoot() const;
+
+    [[nodiscard]] Transform* Find(const std::string& name, bool recursive = false) const;
 
 public:
     [[nodiscard]] Vector3 GetLocalPosition() const;
@@ -42,12 +72,22 @@ public:
     void RotateAroundAxis(const Vector3& axis, float angle);
     void RotateAroundPointInWorldSpace(const Vector3& pointInWorldSpace, const Vector3& axisInWorldSpace, float angle);
 
+    Vector3 TransformPoint(const Vector3& point) const;
+    Vector3 TransformVector3(const Vector3& direction) const;
+
+    Vector3 InverseTransformPoint(const Vector3& point) const;
+    Vector3 InverseTransformVector3(const Vector3& vector, bool affectedByScale = true) const;
+
     [[nodiscard]] Matrix4x4 GetLocalToWorldMatrix() const;
     [[nodiscard]] Matrix4x4 GetLocalToWorldMatrixIgnoreScale() const;
+
     [[nodiscard]] Matrix4x4 GetWorldToLocalMatrix() const;
     [[nodiscard]] Matrix4x4 GetWorldToLocalMatrixIgnoreScale() const;
 
 private:
+    Transform* m_Parent;
+    std::vector<Transform*> m_Children;
+
     Vector3 m_LocalPosition;
     Quaternion m_LocalRotation;
     Vector3 m_LocalScale;

--- a/src/Rendering/RenderSystem.cpp
+++ b/src/Rendering/RenderSystem.cpp
@@ -166,7 +166,7 @@ void RenderSystem::Update()
 
         PushConstant pushConstant
         {
-            .m = gameObject->transform->GetLocalToWorldMatrix(),
+            .m = gameObject->GetTransform()->GetLocalToWorldMatrix(),
             .vp = camera->GetViewProjectionMatrix()
         };
         std::array<PushConstant, 1> pushConstantData = {pushConstant};

--- a/src/Scene/Scene.cpp
+++ b/src/Scene/Scene.cpp
@@ -93,7 +93,11 @@ void Scene::DestroyMultipleObjects(GameObject** ppGameObjects, int count)
 
         for (auto const& child : *(current->GetTransform()))
         {
-            stack.push_back(child->GetGameObject());
+            // m_GameObjectsToDestroy is a comes-for-free visited set, by which the maximum iteration count will be the number of game objects
+            if (!m_GameObjectsToDestroy[child->GetGameObject()])
+            {
+                stack.push_back(child->GetGameObject());
+            }
         }
 
         m_GameObjectsToDestroy[current] = true;

--- a/src/Scene/Scene.cpp
+++ b/src/Scene/Scene.cpp
@@ -58,9 +58,13 @@ void Scene::DestroyObject(GameObject* gameObject)
 {
     auto newLogicalEnd =
         std::remove_if(m_GameObjects.begin(), m_GameObjects.end(), [gameObject](GameObject* pGameObject)
-                       { return pGameObject->GetTransform()->GetRoot()->GetGameObject() == gameObject; });
+                       { return pGameObject == gameObject || pGameObject->GetTransform()->IsChildOf(gameObject->GetTransform()); });
     std::for_each(newLogicalEnd, m_GameObjects.end(), [](GameObject* pGameObject)
-                  { delete pGameObject; });
+                  { LOG_STREAM(DEBUG) << "Destroying GameObject " << pGameObject->GetName() << std::endl;
+                      delete pGameObject; });
+
+    LOG_STREAM(DEBUG) << "Destroyed " << (std::distance(newLogicalEnd, m_GameObjects.end()))
+                      << " GameObjects" << std::endl;
     m_GameObjects.erase(newLogicalEnd, m_GameObjects.end());
 }
 

--- a/src/Scene/Scene.cpp
+++ b/src/Scene/Scene.cpp
@@ -56,12 +56,12 @@ GameObject* Scene::NewObject(std::string name)
 
 void Scene::DestroyObject(GameObject* gameObject)
 {
-    auto it = std::find(m_GameObjects.begin(), m_GameObjects.end(), gameObject);
-    if (it != m_GameObjects.end())
-    {
-        m_GameObjects.erase(it);
-        delete gameObject;
-    }
+    auto newLogicalEnd =
+        std::remove_if(m_GameObjects.begin(), m_GameObjects.end(), [gameObject](GameObject* pGameObject)
+                       { return pGameObject->GetTransform()->GetRoot()->GetGameObject() == pGameObject; });
+    std::for_each(newLogicalEnd, m_GameObjects.end(), [](GameObject* pGameObject)
+                  { delete pGameObject; });
+    m_GameObjects.erase(newLogicalEnd, m_GameObjects.end());
 }
 
 GameObject* Scene::FindObject(const std::string& name)

--- a/src/Scene/Scene.cpp
+++ b/src/Scene/Scene.cpp
@@ -63,9 +63,15 @@ void Scene::DestroyObject(GameObject* gameObject)
                        {
                            if (pGameObject == gameObject || pGameObject->GetTransform()->IsChildOf(gameObject->GetTransform()))
                            {
-                                LOG_STREAM(DEBUG) << "Destroying GameObject " << pGameObject->GetName() << std::endl;
-                                delete pGameObject;
-                                return true;
+                               if (pGameObject == gameObject && pGameObject->GetTransform()->GetParent() != nullptr)
+                               {
+                                   // If the GameObject is the one we want to destroy, we need to remove it from its parent
+                                   // Setting reCalculateLocalTQS to false will prevent unnecessary calculations
+                                   pGameObject->GetTransform()->SetParent(nullptr, false);
+                               }
+                               LOG_STREAM(DEBUG) << "Destroying GameObject " << pGameObject->GetName() << std::endl;
+                               delete pGameObject;
+                               return true;
                            }
                            return false; });
 

--- a/src/Scene/Scene.cpp
+++ b/src/Scene/Scene.cpp
@@ -61,14 +61,14 @@ void Scene::DestroyObject(GameObject* gameObject)
     auto newLogicalEnd =
         std::remove_if(m_GameObjects.begin(), m_GameObjects.end(), [gameObject](GameObject* pGameObject)
                        {
+                           if (pGameObject == gameObject && pGameObject->GetTransform()->GetParent() != nullptr)
+                           {
+                               // If the GameObject is the one we want to destroy, we need to remove it from its parent
+                               // Setting reCalculateLocalTQS to false will prevent unnecessary calculations
+                               pGameObject->GetTransform()->SetParent(nullptr, false);
+                           }
                            if (pGameObject == gameObject || pGameObject->GetTransform()->IsChildOf(gameObject->GetTransform(), true))
                            {
-                               if (pGameObject == gameObject && pGameObject->GetTransform()->GetParent() != nullptr)
-                               {
-                                   // If the GameObject is the one we want to destroy, we need to remove it from its parent
-                                   // Setting reCalculateLocalTQS to false will prevent unnecessary calculations
-                                   pGameObject->GetTransform()->SetParent(nullptr, false);
-                               }
                                LOG_STREAM(DEBUG) << "Destroying GameObject " << pGameObject->GetName() << std::endl;
                                delete pGameObject;
                                return true;

--- a/src/Scene/Scene.cpp
+++ b/src/Scene/Scene.cpp
@@ -56,12 +56,18 @@ GameObject* Scene::NewObject(std::string name)
 
 void Scene::DestroyObject(GameObject* gameObject)
 {
+    // std::remove_if removes the elements by shifting latter elements to the left and leave the higher indices be
+    // So if we want to delete the objects, we need to delete them BEFORE the predicate function returns true
     auto newLogicalEnd =
         std::remove_if(m_GameObjects.begin(), m_GameObjects.end(), [gameObject](GameObject* pGameObject)
-                       { return pGameObject == gameObject || pGameObject->GetTransform()->IsChildOf(gameObject->GetTransform()); });
-    std::for_each(newLogicalEnd, m_GameObjects.end(), [](GameObject* pGameObject)
-                  { LOG_STREAM(DEBUG) << "Destroying GameObject " << pGameObject->GetName() << std::endl;
-                      delete pGameObject; });
+                       {
+                           if (pGameObject == gameObject || pGameObject->GetTransform()->IsChildOf(gameObject->GetTransform()))
+                           {
+                                LOG_STREAM(DEBUG) << "Destroying GameObject " << pGameObject->GetName() << std::endl;
+                                delete pGameObject;
+                                return true;
+                           }
+                           return false; });
 
     LOG_STREAM(DEBUG) << "Destroyed " << (std::distance(newLogicalEnd, m_GameObjects.end()))
                       << " GameObjects" << std::endl;

--- a/src/Scene/Scene.cpp
+++ b/src/Scene/Scene.cpp
@@ -61,7 +61,7 @@ void Scene::DestroyObject(GameObject* gameObject)
     auto newLogicalEnd =
         std::remove_if(m_GameObjects.begin(), m_GameObjects.end(), [gameObject](GameObject* pGameObject)
                        {
-                           if (pGameObject == gameObject || pGameObject->GetTransform()->IsChildOf(gameObject->GetTransform()))
+                           if (pGameObject == gameObject || pGameObject->GetTransform()->IsChildOf(gameObject->GetTransform(), true))
                            {
                                if (pGameObject == gameObject && pGameObject->GetTransform()->GetParent() != nullptr)
                                {

--- a/src/Scene/Scene.cpp
+++ b/src/Scene/Scene.cpp
@@ -58,7 +58,7 @@ void Scene::DestroyObject(GameObject* gameObject)
 {
     auto newLogicalEnd =
         std::remove_if(m_GameObjects.begin(), m_GameObjects.end(), [gameObject](GameObject* pGameObject)
-                       { return pGameObject->GetTransform()->GetRoot()->GetGameObject() == pGameObject; });
+                       { return pGameObject->GetTransform()->GetRoot()->GetGameObject() == gameObject; });
     std::for_each(newLogicalEnd, m_GameObjects.end(), [](GameObject* pGameObject)
                   { delete pGameObject; });
     m_GameObjects.erase(newLogicalEnd, m_GameObjects.end());

--- a/src/Scene/Scene.h
+++ b/src/Scene/Scene.h
@@ -4,7 +4,7 @@
 
 #include <string>
 #include <vector>
-#include <unordered_map>
+#include <unordered_set>
 
 namespace gore
 {
@@ -53,7 +53,6 @@ private:
     std::string m_Name;
 
     std::vector<GameObject*> m_GameObjects;
-    std::unordered_map<GameObject*, bool> m_GameObjectsToDestroy;
 
     static std::vector<Scene*> s_CurrentScenes;
     static Scene* s_ActiveScene;

--- a/src/Scene/Scene.h
+++ b/src/Scene/Scene.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 namespace gore
 {
@@ -33,24 +34,26 @@ public:
     // If we have time to implement this
     // GameObject* NewObject(std::string name = "New GameObject", Vector3 position = Vector3::Zero);
 
-    void DestroyObject(GameObject* gameObject);
+    void DestroyObject(GameObject * pGameObject);
+    void DestroyMultipleObjects(GameObject * *ppGameObjects, int count);
 
     GameObject* FindObject(const std::string& name);
 
-    [[nodiscard]] const std::vector<GameObject*>& GetGameObjects() const { return m_GameObjects; }
+    [[nodiscard]] const std::vector<GameObject*>& GetGameObjects() const
+    {
+        return m_GameObjects;
+    }
 
     void SetAsActive();
     static Scene* GetActiveScene();
 
-    [[nodiscard]] static std::vector<Scene*> GetScenes()
-    {
-        return s_CurrentScenes;
-    }
+    [[nodiscard]] static std::vector<Scene*> GetScenes() { return s_CurrentScenes; }
 
 private:
     std::string m_Name;
 
     std::vector<GameObject*> m_GameObjects;
+    std::unordered_map<GameObject*, bool> m_GameObjectsToDestroy;
 
     static std::vector<Scene*> s_CurrentScenes;
     static Scene* s_ActiveScene;


### PR DESCRIPTION
**Important API change**: 
- `gameObject->transform` => `gameObject->GetTransform()`
- `Quaternion::CreateFromXXXX()` => `Quaternion::FromXXXX()`

Now we have:
- `Transform::SetParent(Transform* newParent, bool recalculateLocal = true)`
  - when `newParent == nullptr` it will simply belong to world space
- `Transform::{Get/Set} World Position/Quaternion/Scale()`
- `Transform::(Inverse)TransformPoint/Vector3(input, bool useScale)`, if `useScale` is `false` the calculation will ignore the **overall Scale in world space** and calculate only based on the transform's global `T` and `R`
- `std::itarator`s: const & non-const, plus normal and reverse: `(r)begin()` `(r)end()`
- A `Find(strName, recursive=false)` which supports recursively finding, by name
- "Destroy children": if some GameObject is destroyed, then all its children, under the whole hierarchy, will be destroyed.
- `Scene.DestroyObject(pGameObject)` and `Scene.DestroyMultipleObjects(ppGameObjects, count)`, and the single-destroying function is simply a forward to `DestroyMultipleObjects(&p, 1)`

And some misc changes:
- `Quaternion::Inverse()` is now exactly the same as `Quaternion::Conjugate()`, which is the reverse rotation. 
  - I don't think there will be anyone really put a non-uniform's quaternion into any practical use
- `Math/TQS.h` for more convenient affine transform's calculation
  - Replace `Transform::T/Q/S` with `TQS Transform::m_LocalTQS`
  - Functions like `Transform::Get{Local<=>World}Matrix()` are now calculated through `TQS` first and then converted to `Matrix4x4`
- Add per-object function `GameObject.Destroy()`. Note that this is a "delete this" operation so use it carefully.

Also, I update SampleApp (by merging from `test-hierarchy`) with handy components like `SelfMove`, `SelfRotate`, `SelfScale`, `SelfDestroyAfterSeconds`, `SwitchParents`, which are controlled by keyboard or by time period.

