### PR TITLE
Optimize DrawData to use packed Draw Stream Struct

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -169,6 +169,10 @@ if (${ENABLE_TEST})
     target_include_directories(${PROJECT_NAME}Test PRIVATE ${COMMON_INCLUDE_FOLDERS} ${PLATFORM_INCLUDE_DIRECTORIES})
     target_compile_definitions(${PROJECT_NAME}Test PRIVATE ${COMMON_DEFINITIONS})
     target_link_libraries(${PROJECT_NAME}Test PRIVATE ${COMMON_LIBRARIES} ${PLATFORM_LIBRARIES})
+    
+    include(CTest)
+    include(Catch)
+    catch_discover_tests(${PROJECT_NAME}Test WORKING_DIRECTORY "$<TARGET_FILE_DIR:${PROJECT_NAME}Test>")
 endif()
 
 # Targets

--- a/src/Rendering/DrawStream/DrawStream.cpp
+++ b/src/Rendering/DrawStream/DrawStream.cpp
@@ -1,0 +1,241 @@
+#include "DrawStream.h"
+
+#include "Utilities/BitWriter.h"
+#include "Utilities/BitReader.h"
+
+namespace gore::renderer
+{
+void CreateDrawStreamFromDrawData(const std::vector<Draw>& drawData, DrawStream& drawStream)
+{
+    if (drawData.empty())
+    {
+        return;
+    }
+
+    // Calculate the size of the draw stream
+    const int maxPerDrawByteSize = sizeof(DrawStateMask) + sizeof(Draw);
+    const size_t maxSize = maxPerDrawByteSize * drawData.size();
+
+    auto& data = drawStream.data;
+    data.resize(maxSize);
+
+    // Loop through the draw data and create the draw stream
+    Draw lastDraw = drawData[0];
+    bool first = true;
+
+    BitWriter writer(data.data(), maxSize);
+    DrawStateMask mask = {};
+
+    for (const auto& draw : drawData)
+    { 
+        mask.mask = 0;
+
+        if (first)
+        {
+            mask.mask = 0xFFFFFFFF;
+
+            writer.Write(mask);
+            writer.Write(draw);
+
+            lastDraw = draw;
+
+            first = false;
+            continue;
+        }
+
+        mask.shader = lastDraw.shader != draw.shader;
+        mask.bindgroup0 = lastDraw.bindGroup[0] != draw.bindGroup[0];
+        mask.bindgroup1 = lastDraw.bindGroup[1] != draw.bindGroup[1];
+        mask.bindgroup2 = lastDraw.bindGroup[2] != draw.bindGroup[2];
+        mask.indexBuffer = lastDraw.indexBuffer != draw.indexBuffer;
+        mask.vertexBuffer = lastDraw.vertexBuffer != draw.vertexBuffer;
+        mask.dynamicBuffer = lastDraw.dynamicBuffer != draw.dynamicBuffer;
+        mask.indexOffset = lastDraw.indexOffset != draw.indexOffset;
+        mask.vertexOffset = lastDraw.vertexOffset != draw.vertexOffset;
+        mask.instanceOffset = lastDraw.instanceOffset != draw.instanceOffset;
+        mask.instanceCount = lastDraw.instanceCount != draw.instanceCount;
+        mask.dynamicBufferOffset = lastDraw.dynamicBufferOffset != draw.dynamicBufferOffset;
+        mask.indexCount = lastDraw.indexCount != draw.indexCount;
+
+        if (mask.mask != 0)
+        {
+            writer.Write(mask);
+        }
+
+        if (mask.shader != 0)
+        {
+            writer.Write(draw.shader);
+        }
+
+        if (mask.bindgroup0 != 0)
+        {
+            writer.Write(draw.bindGroup[0]);
+        }
+
+        if (mask.bindgroup1 != 0)
+        {
+            writer.Write(draw.bindGroup[1]);
+        }
+
+        if (mask.bindgroup2 != 0)
+        {
+            writer.Write(draw.bindGroup[2]);
+        }
+
+        if (mask.indexBuffer != 0)
+        {
+            writer.Write(draw.indexBuffer);
+        }
+
+        if (mask.vertexBuffer != 0)
+        {
+            writer.Write(draw.vertexBuffer);
+        }
+
+        if (mask.dynamicBuffer != 0)
+        {
+            writer.Write(draw.dynamicBuffer);
+        }
+
+        if (mask.indexOffset != 0)
+        {
+            writer.Write(draw.indexOffset);
+        }
+
+        if (mask.vertexOffset != 0)
+        {
+            writer.Write(draw.vertexOffset);
+        }
+
+        if (mask.instanceOffset != 0)
+        {
+            writer.Write(draw.instanceOffset);
+        }
+
+        if (mask.instanceCount != 0)
+        {
+            writer.Write(draw.instanceCount);
+        }
+
+        if (mask.dynamicBufferOffset != 0)
+        {
+            writer.Write(draw.dynamicBufferOffset);
+        }
+
+        if (mask.indexCount != 0)
+        {
+            writer.Write(draw.indexCount);
+        }
+    }
+
+    writer.ShrinkToFit();
+}
+
+void ScheduleDrawStream(RenderContext& renderContext, DrawStream& drawStream, vk::CommandBuffer commandBuffer)
+{
+    BitReader reader(drawStream.data.data(), drawStream.data.size());
+    
+    DrawStateMask mask = {};
+
+    GraphicsPipeline graphicsPipeline = {};
+    uint32_t indexOffset = 0;
+    uint32_t vertexOffset = 0;
+    uint32_t instanceOffset = 0;
+    uint32_t instanceCount = 0;
+    uint32_t dynamicBufferOffset = 0;
+    uint32_t indexCount = 0;
+
+    while (reader.GetBitsRemaining() > 0)
+    {
+        mask = reader.Read<DrawStateMask>();
+
+        if (mask.shader != 0)
+        {
+            auto shaderHandle = reader.Read<GraphicsPipelineHandle>();
+            graphicsPipeline = renderContext.GetGraphicsPipeline(shaderHandle);
+            commandBuffer.bindPipeline(vk::PipelineBindPoint::eGraphics, graphicsPipeline.pipeline);
+        }
+
+        if (mask.bindgroup0 != 0)
+        {
+            auto bindGroupHandle = reader.Read<BindGroupHandle>();
+            auto& bindGroup = renderContext.GetBindGroup(bindGroupHandle);
+            commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, graphicsPipeline.layout, 0, {bindGroup.set}, {});
+        }
+
+        if (mask.bindgroup1 != 0)
+        {
+            auto bindGroupHandle = reader.Read<BindGroupHandle>();
+            auto& bindGroup = renderContext.GetBindGroup(bindGroupHandle);
+            commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, graphicsPipeline.layout, 1, {bindGroup.set}, {});
+        }
+
+        if (mask.bindgroup2 != 0)
+        {
+            auto bindGroupHandle = reader.Read<BindGroupHandle>();
+            auto& bindGroup = renderContext.GetBindGroup(bindGroupHandle);
+            commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, graphicsPipeline.layout, 2, {bindGroup.set}, {});
+        }
+
+        if (mask.indexBuffer != 0)
+        {
+            auto bufferHandle = reader.Read<BufferHandle>();
+            auto& buffer = renderContext.GetBuffer(bufferHandle);
+            commandBuffer.bindIndexBuffer(buffer.vkBuffer, 0, vk::IndexType::eUint16);
+        }
+
+        if (mask.vertexBuffer != 0)
+        {
+            auto bufferHandle = reader.Read<BufferHandle>();
+            auto& buffer = renderContext.GetBuffer(bufferHandle);
+            commandBuffer.bindVertexBuffers(0, {buffer.vkBuffer}, {0});
+        }
+
+        if (mask.dynamicBuffer != 0)
+        {
+            auto dynamicBufferHandle = reader.Read<DynamicBufferHandle>();
+            auto& dynamicBuffer = renderContext.GetDynamicBuffer(dynamicBufferHandle);
+            commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, graphicsPipeline.layout, 3, {dynamicBuffer.set}, {0});
+        }
+
+        if (mask.indexOffset != 0)
+        {
+            indexOffset = reader.Read<uint32_t>();
+        }
+
+        if (mask.vertexOffset != 0)
+        {
+            vertexOffset = reader.Read<uint32_t>();
+        }
+
+        if (mask.instanceOffset != 0)
+        {
+            instanceOffset = reader.Read<uint32_t>();
+        }
+
+        if (mask.instanceCount != 0)
+        {
+            instanceCount = reader.Read<uint32_t>();
+        }
+
+        if (mask.dynamicBufferOffset != 0)
+        {
+            dynamicBufferOffset = reader.Read<uint32_t>();
+        }
+
+        if (mask.indexCount != 0)
+        {
+            indexCount = reader.Read<uint32_t>();
+        }
+
+        if (mask.indexCount != 0)
+        {
+            commandBuffer.drawIndexed(indexCount, instanceCount, indexOffset, vertexOffset, instanceOffset);
+        }
+        else
+        {
+            commandBuffer.draw(indexCount, instanceCount, vertexOffset, instanceOffset);
+        }
+    }
+}
+} // namespace gore::renderer

--- a/src/Rendering/DrawStream/DrawStream.cpp
+++ b/src/Rendering/DrawStream/DrawStream.cpp
@@ -5,6 +5,79 @@
 
 namespace gore::renderer
 {
+static inline void WriteDraw(BitWriter& writer, const DrawStateMask mask, const Draw draw)
+{
+    if (mask.mask == 0)
+    {
+        return;
+    }
+
+    if (mask.shader != 0)
+    {
+        writer.Write(draw.shader);
+    }
+
+    if (mask.bindgroup0 != 0)
+    {
+        writer.Write(draw.bindGroup[0]);
+    }
+
+    if (mask.bindgroup1 != 0)
+    {
+        writer.Write(draw.bindGroup[1]);
+    }
+
+    if (mask.bindgroup2 != 0)
+    {
+        writer.Write(draw.bindGroup[2]);
+    }
+
+    if (mask.indexBuffer != 0)
+    {
+        writer.Write(draw.indexBuffer);
+    }
+
+    if (mask.vertexBuffer != 0)
+    {
+        writer.Write(draw.vertexBuffer);
+    }
+
+    if (mask.dynamicBuffer != 0)
+    {
+        writer.Write(draw.dynamicBuffer);
+    }
+
+    if (mask.indexOffset != 0)
+    {
+        writer.Write(draw.indexOffset);
+    }
+
+    if (mask.vertexOffset != 0)
+    {
+        writer.Write(draw.vertexOffset);
+    }
+
+    if (mask.instanceOffset != 0)
+    {
+        writer.Write(draw.instanceOffset);
+    }
+
+    if (mask.instanceCount != 0)
+    {
+        writer.Write(draw.instanceCount);
+    }
+
+    if (mask.dynamicBufferOffset != 0)
+    {
+        writer.Write(draw.dynamicBufferOffset);
+    }
+
+    if (mask.indexCount != 0)
+    {
+        writer.Write(draw.indexCount);
+    }
+}
+
 void CreateDrawStreamFromDrawData(const std::vector<Draw>& drawData, DrawStream& drawStream)
 {
     if (drawData.empty())
@@ -14,28 +87,39 @@ void CreateDrawStreamFromDrawData(const std::vector<Draw>& drawData, DrawStream&
 
     // Calculate the size of the draw stream
     const int maxPerDrawByteSize = sizeof(DrawStateMask) + sizeof(Draw);
-    const size_t maxSize = maxPerDrawByteSize * drawData.size();
-
-    auto& data = drawStream.data;
-    data.resize(maxSize);
+    const size_t maxSize         = maxPerDrawByteSize * drawData.size();
 
     // Loop through the draw data and create the draw stream
     Draw lastDraw = drawData[0];
-    bool first = true;
+    bool first    = true;
 
-    BitWriter writer(data.data(), maxSize);
+    BitWriter writer(maxSize);
     DrawStateMask mask = {};
 
     for (const auto& draw : drawData)
-    { 
+    {
         mask.mask = 0;
 
         if (first)
         {
-            mask.mask = 0xFFFFFFFF;
+            mask.shader              = draw.shader.empty() == false;
+            mask.bindgroup0          = draw.bindGroup[0].empty() == false;
+            mask.bindgroup1          = draw.bindGroup[1].empty() == false;
+            mask.bindgroup2          = draw.bindGroup[2].empty() == false;
+            mask.indexBuffer         = draw.indexBuffer.empty() == false;
+            mask.vertexBuffer        = draw.vertexBuffer.empty() == false;
+            mask.dynamicBuffer       = draw.dynamicBuffer.empty() == false;
+            mask.indexOffset         = draw.indexOffset != 0;
+            mask.vertexOffset        = draw.vertexOffset != 0;
+            mask.instanceOffset      = draw.instanceOffset != 0;
+            mask.instanceCount       = draw.instanceCount != 0;
+            mask.dynamicBufferOffset = draw.dynamicBufferOffset != 0;
+            mask.indexCount          = draw.indexCount != 0;
 
-            writer.Write(mask);
-            writer.Write(draw);
+            if (mask.mask != 0)
+                writer.Write(mask);
+
+            WriteDraw(writer, mask, draw);
 
             lastDraw = draw;
 
@@ -43,107 +127,42 @@ void CreateDrawStreamFromDrawData(const std::vector<Draw>& drawData, DrawStream&
             continue;
         }
 
-        mask.shader = lastDraw.shader != draw.shader;
-        mask.bindgroup0 = lastDraw.bindGroup[0] != draw.bindGroup[0];
-        mask.bindgroup1 = lastDraw.bindGroup[1] != draw.bindGroup[1];
-        mask.bindgroup2 = lastDraw.bindGroup[2] != draw.bindGroup[2];
-        mask.indexBuffer = lastDraw.indexBuffer != draw.indexBuffer;
-        mask.vertexBuffer = lastDraw.vertexBuffer != draw.vertexBuffer;
-        mask.dynamicBuffer = lastDraw.dynamicBuffer != draw.dynamicBuffer;
-        mask.indexOffset = lastDraw.indexOffset != draw.indexOffset;
-        mask.vertexOffset = lastDraw.vertexOffset != draw.vertexOffset;
-        mask.instanceOffset = lastDraw.instanceOffset != draw.instanceOffset;
-        mask.instanceCount = lastDraw.instanceCount != draw.instanceCount;
+        mask.shader              = lastDraw.shader != draw.shader;
+        mask.bindgroup0          = lastDraw.bindGroup[0] != draw.bindGroup[0];
+        mask.bindgroup1          = lastDraw.bindGroup[1] != draw.bindGroup[1];
+        mask.bindgroup2          = lastDraw.bindGroup[2] != draw.bindGroup[2];
+        mask.indexBuffer         = lastDraw.indexBuffer != draw.indexBuffer;
+        mask.vertexBuffer        = lastDraw.vertexBuffer != draw.vertexBuffer;
+        mask.dynamicBuffer       = lastDraw.dynamicBuffer != draw.dynamicBuffer;
+        mask.indexOffset         = lastDraw.indexOffset != draw.indexOffset;
+        mask.vertexOffset        = lastDraw.vertexOffset != draw.vertexOffset;
+        mask.instanceOffset      = lastDraw.instanceOffset != draw.instanceOffset;
+        mask.instanceCount       = lastDraw.instanceCount != draw.instanceCount;
         mask.dynamicBufferOffset = lastDraw.dynamicBufferOffset != draw.dynamicBufferOffset;
-        mask.indexCount = lastDraw.indexCount != draw.indexCount;
-
-        if (mask.mask != 0)
-        {
-            writer.Write(mask);
-        }
-
-        if (mask.shader != 0)
-        {
-            writer.Write(draw.shader);
-        }
-
-        if (mask.bindgroup0 != 0)
-        {
-            writer.Write(draw.bindGroup[0]);
-        }
-
-        if (mask.bindgroup1 != 0)
-        {
-            writer.Write(draw.bindGroup[1]);
-        }
-
-        if (mask.bindgroup2 != 0)
-        {
-            writer.Write(draw.bindGroup[2]);
-        }
-
-        if (mask.indexBuffer != 0)
-        {
-            writer.Write(draw.indexBuffer);
-        }
-
-        if (mask.vertexBuffer != 0)
-        {
-            writer.Write(draw.vertexBuffer);
-        }
-
-        if (mask.dynamicBuffer != 0)
-        {
-            writer.Write(draw.dynamicBuffer);
-        }
-
-        if (mask.indexOffset != 0)
-        {
-            writer.Write(draw.indexOffset);
-        }
-
-        if (mask.vertexOffset != 0)
-        {
-            writer.Write(draw.vertexOffset);
-        }
-
-        if (mask.instanceOffset != 0)
-        {
-            writer.Write(draw.instanceOffset);
-        }
-
-        if (mask.instanceCount != 0)
-        {
-            writer.Write(draw.instanceCount);
-        }
-
-        if (mask.dynamicBufferOffset != 0)
-        {
-            writer.Write(draw.dynamicBufferOffset);
-        }
-
-        if (mask.indexCount != 0)
-        {
-            writer.Write(draw.indexCount);
-        }
+        mask.indexCount          = lastDraw.indexCount != draw.indexCount;
+        
+        writer.Write(mask);
+        WriteDraw(writer, mask, draw);
     }
 
     writer.ShrinkToFit();
+
+    drawStream.data.assign(writer.GetData(), writer.GetData() + writer.GetByteWritten());
 }
 
 void ScheduleDrawStream(RenderContext& renderContext, DrawStream& drawStream, vk::CommandBuffer commandBuffer)
 {
     BitReader reader(drawStream.data.data(), drawStream.data.size());
-    
+
     DrawStateMask mask = {};
 
     GraphicsPipeline graphicsPipeline = {};
-    uint32_t indexOffset = 0;
-    uint32_t vertexOffset = 0;
-    uint32_t instanceOffset = 0;
-    uint32_t instanceCount = 0;
-    uint32_t dynamicBufferOffset = 0;
-    uint32_t indexCount = 0;
+    uint32_t indexOffset              = 0;
+    uint32_t vertexOffset             = 0;
+    uint32_t instanceOffset           = 0;
+    uint32_t instanceCount            = 0;
+    uint32_t dynamicBufferOffset      = 0;
+    uint32_t indexCount               = 0;
 
     while (reader.GetBitsRemaining() > 0)
     {
@@ -152,49 +171,49 @@ void ScheduleDrawStream(RenderContext& renderContext, DrawStream& drawStream, vk
         if (mask.shader != 0)
         {
             auto shaderHandle = reader.Read<GraphicsPipelineHandle>();
-            graphicsPipeline = renderContext.GetGraphicsPipeline(shaderHandle);
+            graphicsPipeline  = renderContext.GetGraphicsPipeline(shaderHandle);
             commandBuffer.bindPipeline(vk::PipelineBindPoint::eGraphics, graphicsPipeline.pipeline);
         }
 
         if (mask.bindgroup0 != 0)
         {
             auto bindGroupHandle = reader.Read<BindGroupHandle>();
-            auto& bindGroup = renderContext.GetBindGroup(bindGroupHandle);
+            auto& bindGroup      = renderContext.GetBindGroup(bindGroupHandle);
             commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, graphicsPipeline.layout, 0, {bindGroup.set}, {});
         }
 
         if (mask.bindgroup1 != 0)
         {
             auto bindGroupHandle = reader.Read<BindGroupHandle>();
-            auto& bindGroup = renderContext.GetBindGroup(bindGroupHandle);
+            auto& bindGroup      = renderContext.GetBindGroup(bindGroupHandle);
             commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, graphicsPipeline.layout, 1, {bindGroup.set}, {});
         }
 
         if (mask.bindgroup2 != 0)
         {
             auto bindGroupHandle = reader.Read<BindGroupHandle>();
-            auto& bindGroup = renderContext.GetBindGroup(bindGroupHandle);
+            auto& bindGroup      = renderContext.GetBindGroup(bindGroupHandle);
             commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, graphicsPipeline.layout, 2, {bindGroup.set}, {});
         }
 
         if (mask.indexBuffer != 0)
         {
             auto bufferHandle = reader.Read<BufferHandle>();
-            auto& buffer = renderContext.GetBuffer(bufferHandle);
+            auto& buffer      = renderContext.GetBuffer(bufferHandle);
             commandBuffer.bindIndexBuffer(buffer.vkBuffer, 0, vk::IndexType::eUint16);
         }
 
         if (mask.vertexBuffer != 0)
         {
             auto bufferHandle = reader.Read<BufferHandle>();
-            auto& buffer = renderContext.GetBuffer(bufferHandle);
+            auto& buffer      = renderContext.GetBuffer(bufferHandle);
             commandBuffer.bindVertexBuffers(0, {buffer.vkBuffer}, {0});
         }
 
         if (mask.dynamicBuffer != 0)
         {
             auto dynamicBufferHandle = reader.Read<DynamicBufferHandle>();
-            auto& dynamicBuffer = renderContext.GetDynamicBuffer(dynamicBufferHandle);
+            auto& dynamicBuffer      = renderContext.GetDynamicBuffer(dynamicBufferHandle);
             commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, graphicsPipeline.layout, 3, {dynamicBuffer.set}, {0});
         }
 

--- a/src/Rendering/DrawStream/DrawStream.h
+++ b/src/Rendering/DrawStream/DrawStream.h
@@ -6,17 +6,31 @@
 
 namespace gore::renderer
 {
-
-
-struct RendererSort
+union DrawStateMask
 {
-    // custom compare function
-    static operator()(const Renderer* a, const Renderer* b) const
+    struct
     {
-        return a->GetRenderQueue() < b->GetRenderQueue();
-    }
+        uint32_t pipeline : 1;
+        uint32_t bindgroup0 : 1;
+        uint32_t bindgroup1 : 1;
+        uint32_t bindgroup2 : 1;
+        uint32_t indexBuffer : 1;
+        uint32_t vertexBuffer : 1;
+        uint32_t dynamicBuffer : 1;
+        uint32_t indexOffset : 1;
+        uint32_t vertexOffset : 1;
+        uint32_t instanceOffset : 1;
+        uint32_t instanceCount : 1;
+        uint32_t dynamicBufferOffset : 1;
+
+        uint32_t pack : 20;
+    };
+
+    uint32_t mask;
 };
+static_assert(sizeof(DrawStateMask) == 4, "DrawStateMask should be 4 bytes");
 
-
-
+struct DrawStream
+{
+};
 } // namespace gore::renderer

--- a/src/Rendering/DrawStream/DrawStream.h
+++ b/src/Rendering/DrawStream/DrawStream.h
@@ -4,6 +4,7 @@
 #include "Draw.h"
 
 #include <vector>
+#include <unordered_map>
 
 namespace gore::renderer
 {
@@ -11,7 +12,7 @@ union DrawStateMask
 {
     struct
     {
-        uint32_t pipeline : 1;
+        uint32_t shader : 1;
         uint32_t bindgroup0 : 1;
         uint32_t bindgroup1 : 1;
         uint32_t bindgroup2 : 1;
@@ -23,18 +24,20 @@ union DrawStateMask
         uint32_t instanceOffset : 1;
         uint32_t instanceCount : 1;
         uint32_t dynamicBufferOffset : 1;
+        uint32_t indexCount : 1;
 
-        uint32_t pack : 20;
+        uint32_t pack : 19;
     };
 
     uint32_t mask;
 };
 static_assert(sizeof(DrawStateMask) == 4, "DrawStateMask should be 4 bytes");
 
-struct DrawStream
+struct DrawStream final
 {
     std::vector<uint8_t> data;
 };
 
 void CreateDrawStreamFromDrawData(const std::vector<Draw>& drawData, DrawStream& drawStream);
-} // namespace gore::renderer
+void ScheduleDrawStream(RenderContext& renderContext, DrawStream& drawStream, vk::CommandBuffer commandBuffer);
+} // namespace gore::renderer   

--- a/src/Rendering/DrawStream/DrawStream.h
+++ b/src/Rendering/DrawStream/DrawStream.h
@@ -3,6 +3,7 @@
 #include "Prefix.h"
 #include "Draw.h"
 
+#include <vector>
 
 namespace gore::renderer
 {
@@ -32,5 +33,8 @@ static_assert(sizeof(DrawStateMask) == 4, "DrawStateMask should be 4 bytes");
 
 struct DrawStream
 {
+    std::vector<uint8_t> data;
 };
+
+void CreateDrawStreamFromDrawData(const std::vector<Draw>& drawData, DrawStream& drawStream);
 } // namespace gore::renderer

--- a/src/Rendering/Pipeline.h
+++ b/src/Rendering/Pipeline.h
@@ -12,11 +12,6 @@ namespace gore
 
 struct Pipeline
 {
-    Pipeline(vk::Pipeline&& inPipeline) :
-        pipeline(std::move(inPipeline))
-    {
-    }
-
     vk::PipelineLayout layout;
     vk::Pipeline pipeline;
 };

--- a/src/Rendering/RenderContext.cpp
+++ b/src/Rendering/RenderContext.cpp
@@ -353,8 +353,9 @@ GraphicsPipelineHandle RenderContext::CreateGraphicsPipeline(GraphicsPipelineDes
         createInfo.pNext = &rfInfo;
     }
 
-    GraphicsPipeline graphicsPipeline(std::move(VULKAN_DEVICE.createGraphicsPipeline(nullptr, createInfo).value));
-    graphicsPipeline.layout = pipelineLayout;
+    GraphicsPipeline graphicsPipeline;
+    graphicsPipeline.pipeline = VULKAN_DEVICE.createGraphicsPipeline(nullptr, createInfo).value;
+    graphicsPipeline.layout   = pipelineLayout;
 
     SetObjectDebugName(graphicsPipeline.pipeline, desc.debugName);
 

--- a/src/Rendering/RenderSystem.cpp
+++ b/src/Rendering/RenderSystem.cpp
@@ -152,6 +152,9 @@ void RenderSystem::PrepareDrawData()
     std::vector<Draw> sortedDrawData;
     PrepareDrawDataAndSort(info, gameObjects, sortedDrawData);
 
+    DrawStream drawStream;
+    CreateDrawStreamFromDrawData(sortedDrawData, drawStream);
+
     // TODO: check if the draw data is already in the map
     m_DrawData.clear();
 
@@ -159,7 +162,7 @@ void RenderSystem::PrepareDrawData()
     key.passName = info.passName;
     key.alphaMode = info.alphaMode;
 
-    m_DrawData[key] = sortedDrawData;
+    m_DrawData[key] = drawStream;
 }
 
 void RenderSystem::Update()
@@ -947,7 +950,14 @@ void RenderSystem::DrawTriangle(vk::CommandBuffer commandBuffer)
 {    
     DrawCacheKey key = { "ForwardPass", AlphaMode::Opaque };
 
-    ScheduleDraws(*m_RenderContext, m_DrawData, key, commandBuffer);
+    if (m_DrawData.find(key) != m_DrawData.end())
+    {
+        ScheduleDrawStream(*m_RenderContext, m_DrawData[key], commandBuffer);
+    }
+
+    // ScheduleDrawStream(*m_RenderContext, m_DrawData, commandBuffer);
+
+    // ScheduleDraws(*m_RenderContext, m_DrawData, key, commandBuffer);
 
     // commandBuffer.bindPipeline(vk::PipelineBindPoint::eGraphics, m_RenderContext->GetGraphicsPipeline(m_TrianglePipelineHandle).pipeline);
     // commandBuffer.draw(3, 1, 0, 0);

--- a/src/Rendering/RenderSystem.h
+++ b/src/Rendering/RenderSystem.h
@@ -20,7 +20,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "Rendering/DrawStream/Draw.h"
+#include "Rendering/DrawStream/DrawStream.h"
 
 #define RPS_VK_RUNTIME 1
 #include "rps/rps.h"
@@ -235,7 +235,7 @@ private:
     GraphicsCaps m_GraphicsCaps;
 
     // TODO: Change this to drawStream
-    std::unordered_map<DrawCacheKey, std::vector<Draw>> m_DrawData;
+    std::unordered_map<DrawCacheKey, DrawStream> m_DrawData;
 private:
     void UploadPerframeGlobalConstantBuffer(uint32_t imageIndex);
 

--- a/src/Test/BitReaderWriterTest.cpp
+++ b/src/Test/BitReaderWriterTest.cpp
@@ -4,15 +4,97 @@
 #include "../Utilities/BitReader.h"
 #include "../Utilities/BitWriter.h"
 
-using namespace gore;
-
-TEST_CASE("BitReaderWriterTest", "[single-file]")
+namespace gore
 {
-    BitReader reader(nullptr, 0);
-    REQUIRE(reader.GetBitsCount() == 0);
-    
-    BitWriter writer(0, false);
-    REQUIRE(writer.GetBitsCount() == 0);
+class BitWriterTest
+{
+public:
+    BitWriterTest() :
+        buffer(16, 0),
+        bitWriter(buffer.size() * 8, true)
+    {
+    }
+
+    std::vector<uint8_t> buffer;
+    BitWriter bitWriter;
+};
+
+TEST_CASE_METHOD(BitWriterTest, "BitWriter Initialization", "[BitWriter]")
+{
+    REQUIRE(bitWriter.GetBitsCount() == 128);
+    REQUIRE(bitWriter.GetBitsWritten() == 0);
+    REQUIRE(bitWriter.GetBitsRemaining() == 128);
 }
 
+TEST_CASE_METHOD(BitWriterTest, "BitWriter WriteUInt8", "[BitWriter]")
+{
+    bitWriter.WriteUInt8(0xFF);
+    REQUIRE(bitWriter.GetBitsWritten() == 8);
+    REQUIRE(bitWriter.GetBitsRemaining() == 120);
+}
+
+TEST_CASE_METHOD(BitWriterTest, "BitWriter WriteUInt16", "[BitWriter]")
+{
+    bitWriter.WriteUInt16(0xFFFF);
+    REQUIRE(bitWriter.GetBitsWritten() == 16);
+    REQUIRE(bitWriter.GetBitsRemaining() == 112);
+}
+
+TEST_CASE_METHOD(BitWriterTest, "BitWriter WriteUInt32", "[BitWriter]")
+{
+    bitWriter.WriteUInt32(0xFFFFFFFF);
+    REQUIRE(bitWriter.GetBitsWritten() == 32);
+    REQUIRE(bitWriter.GetBitsRemaining() == 96);
+}
+
+TEST_CASE_METHOD(BitWriterTest, "BitWriter AllowResize", "[BitWriter]")
+{
+    REQUIRE(bitWriter.IsAllowResize() == true);
+}
+
+class BitReaderTest
+{
+public:
+    BitReaderTest() :
+        data(10, 0),
+        bitReader(data.data(), data.size())
+    {
+        data[0] = 0x10; // 00010000
+        data[1] = 0x20; // 00100000
+        data[2] = 0x40; // 01000000
+        data[3] = 0x80; // 10000000
+    }
+
+    std::vector<uint8_t> data;
+    BitReader bitReader;
+};
+
+TEST_CASE_METHOD(BitReaderTest, "BitReader Initialization", "[BitReader]")
+{
+    REQUIRE(bitReader.GetBitsCount() == 80);
+    REQUIRE(bitReader.GetBitsRead() == 0);
+    REQUIRE(bitReader.GetBitsRemaining() == 80);
+}
+
+TEST_CASE_METHOD(BitReaderTest, "BitReader ReadUInt8", "[BitReader]")
+{
+    REQUIRE(bitReader.ReadUInt8() == 16);
+    REQUIRE(bitReader.GetBitsRead() == 8);
+    REQUIRE(bitReader.GetBitsRemaining() == 72);
+}
+
+TEST_CASE_METHOD(BitReaderTest, "BitReader ReadUInt16", "[BitReader]")
+{
+    REQUIRE(bitReader.ReadUInt16() == 0x2010);
+    REQUIRE(bitReader.GetBitsRead() == 16);
+    REQUIRE(bitReader.GetBitsRemaining() == 64);
+}
+
+TEST_CASE_METHOD(BitReaderTest, "BitReader ReadUInt32", "[BitReader]")
+{
+    REQUIRE(bitReader.ReadUInt32() == 0x80402010);
+    REQUIRE(bitReader.GetBitsRead() == 32);
+    REQUIRE(bitReader.GetBitsRemaining() == 48);
+}
+} // namespace gore
 #endif // ENABLE_TEST

--- a/src/Test/BitReaderWriterTest.cpp
+++ b/src/Test/BitReaderWriterTest.cpp
@@ -28,30 +28,30 @@ struct TestStruct
 
 TEST_CASE_METHOD(BitWriterTest, "BitWriter Initialization", "[BitWriter]")
 {
-    REQUIRE(bitWriter.GetBitsCount() == 128);
-    REQUIRE(bitWriter.GetBitsWritten() == 0);
-    REQUIRE(bitWriter.GetBitsRemaining() == 128);
+    REQUIRE(bitWriter.GetByteCount() == 128);
+    REQUIRE(bitWriter.GetByteWritten() == 0);
+    REQUIRE(bitWriter.GetByteRemaining() == 128);
 }
 
 TEST_CASE_METHOD(BitWriterTest, "BitWriter WriteUInt8", "[BitWriter]")
 {
     bitWriter.WriteUInt8(0xFF);
-    REQUIRE(bitWriter.GetBitsWritten() == 8);
-    REQUIRE(bitWriter.GetBitsRemaining() == 120);
+    REQUIRE(bitWriter.GetByteWritten() == 8);
+    REQUIRE(bitWriter.GetByteRemaining() == 120);
 }
 
 TEST_CASE_METHOD(BitWriterTest, "BitWriter WriteUInt16", "[BitWriter]")
 {
     bitWriter.WriteUInt16(0xFFFF);
-    REQUIRE(bitWriter.GetBitsWritten() == 16);
-    REQUIRE(bitWriter.GetBitsRemaining() == 112);
+    REQUIRE(bitWriter.GetByteWritten() == 16);
+    REQUIRE(bitWriter.GetByteRemaining() == 112);
 }
 
 TEST_CASE_METHOD(BitWriterTest, "BitWriter WriteUInt32", "[BitWriter]")
 {
     bitWriter.WriteUInt32(0xFFFFFFFF);
-    REQUIRE(bitWriter.GetBitsWritten() == 32);
-    REQUIRE(bitWriter.GetBitsRemaining() == 96);
+    REQUIRE(bitWriter.GetByteWritten() == 32);
+    REQUIRE(bitWriter.GetByteRemaining() == 96);
 }
 
 TEST_CASE_METHOD(BitWriterTest, "BitWriter AllowResize", "[BitWriter]")
@@ -63,8 +63,8 @@ TEST_CASE_METHOD(BitWriterTest, "BitWriter Write Struct", "[BitWriter]")
 {
     TestStruct testStruct = {0x01, 0x0203, 0x04050607};
     bitWriter.Write(testStruct);
-    REQUIRE(bitWriter.GetBitsWritten() == sizeof(TestStruct) * 8);
-    REQUIRE(bitWriter.GetBitsRemaining() == 128 - sizeof(TestStruct) * 8);
+    REQUIRE(bitWriter.GetByteWritten() == sizeof(TestStruct) * 8);
+    REQUIRE(bitWriter.GetByteRemaining() == 128 - sizeof(TestStruct) * 8);
 }
 
 class BitReaderTest

--- a/src/Test/BitReaderWriterTest.cpp
+++ b/src/Test/BitReaderWriterTest.cpp
@@ -1,0 +1,18 @@
+#include "TestPrefix.h"
+#ifdef ENABLE_TEST
+
+#include "../Utilities/BitReader.h"
+#include "../Utilities/BitWriter.h"
+
+using namespace gore;
+
+TEST_CASE("BitReaderWriterTest", "[single-file]")
+{
+    BitReader reader(nullptr, 0);
+    REQUIRE(reader.GetBitsCount() == 0);
+    
+    BitWriter writer(0, false);
+    REQUIRE(writer.GetBitsCount() == 0);
+}
+
+#endif // ENABLE_TEST

--- a/src/Test/BitReaderWriterTest.cpp
+++ b/src/Test/BitReaderWriterTest.cpp
@@ -19,6 +19,13 @@ public:
     BitWriter bitWriter;
 };
 
+struct TestStruct
+{
+    uint8_t a;
+    uint16_t b;
+    uint32_t c;
+};
+
 TEST_CASE_METHOD(BitWriterTest, "BitWriter Initialization", "[BitWriter]")
 {
     REQUIRE(bitWriter.GetBitsCount() == 128);
@@ -50,6 +57,14 @@ TEST_CASE_METHOD(BitWriterTest, "BitWriter WriteUInt32", "[BitWriter]")
 TEST_CASE_METHOD(BitWriterTest, "BitWriter AllowResize", "[BitWriter]")
 {
     REQUIRE(bitWriter.IsAllowResize() == true);
+}
+
+TEST_CASE_METHOD(BitWriterTest, "BitWriter Write Struct", "[BitWriter]")
+{
+    TestStruct testStruct = {0x01, 0x0203, 0x04050607};
+    bitWriter.Write(testStruct);
+    REQUIRE(bitWriter.GetBitsWritten() == sizeof(TestStruct) * 8);
+    REQUIRE(bitWriter.GetBitsRemaining() == 128 - sizeof(TestStruct) * 8);
 }
 
 class BitReaderTest
@@ -96,5 +111,18 @@ TEST_CASE_METHOD(BitReaderTest, "BitReader ReadUInt32", "[BitReader]")
     REQUIRE(bitReader.GetBitsRead() == 32);
     REQUIRE(bitReader.GetBitsRemaining() == 48);
 }
+
+TEST_CASE_METHOD(BitReaderTest, "BitReader Read Struct", "[BitReader]")
+{
+    TestStruct testStruct = {0x01, 0x0203, 0x04050607};
+    std::memcpy(data.data(), &testStruct, sizeof(TestStruct));
+    TestStruct readStruct = bitReader.Read<TestStruct>();
+    REQUIRE(readStruct.a == 0x01);
+    REQUIRE(readStruct.b == 0x0203);
+    REQUIRE(readStruct.c == 0x04050607);
+    REQUIRE(bitReader.GetBitsRead() == sizeof(TestStruct) * 8);
+    REQUIRE(bitReader.GetBitsRemaining() == 80 - sizeof(TestStruct) * 8);
+}
+
 } // namespace gore
 #endif // ENABLE_TEST

--- a/src/Test/TestExampleTest.cpp
+++ b/src/Test/TestExampleTest.cpp
@@ -1,18 +1,18 @@
-// #include "TestPrefix.h"
-// #ifdef ENABLE_TEST
+#include "TestPrefix.h"
+#ifdef ENABLE_TEST
 
-// static int Factorial( int number ) {
-//    return number <= 1 ? number : Factorial( number - 1 ) * number;  // fail
-// }
+static int Factorial( int number ) {
+   return number <= 1 ? number : Factorial( number - 1 ) * number;  // fail
+}
 
-// TEST_CASE( "Factorial of 0 is 1 (fail)", "[single-file]" ) {
-//     REQUIRE( Factorial(0) == 1 );
-// }
+TEST_CASE( "Factorial of 0 is 1 (fail)", "[single-file]" ) {
+    REQUIRE( Factorial(0) == 1 );
+}
 
-// TEST_CASE( "Factorials of 1 and higher are computed (pass)", "[single-file]" ) {
-//     REQUIRE( Factorial(1) == 1 );
-//     REQUIRE( Factorial(2) == 2 );
-//     REQUIRE( Factorial(3) == 6 );
-//     REQUIRE( Factorial(10) == 3628800 );
-// }
-// #endif
+TEST_CASE( "Factorials of 1 and higher are computed (pass)", "[single-file]" ) {
+    REQUIRE( Factorial(1) == 1 );
+    REQUIRE( Factorial(2) == 2 );
+    REQUIRE( Factorial(3) == 6 );
+    REQUIRE( Factorial(10) == 3628800 );
+}
+#endif

--- a/src/Utilities/BitReader.cpp
+++ b/src/Utilities/BitReader.cpp
@@ -1,0 +1,49 @@
+#include "BitReader.h"
+
+#include <stdexcept>
+
+namespace gore
+{
+BitReader::BitReader(void* data, size_t count)
+    : m_Data(reinterpret_cast<uint8_t*>(data), reinterpret_cast<uint8_t*>(data) + count)
+    , m_Count(count)
+    , m_Index(0)
+{
+}
+
+uint8_t BitReader::ReadUInt8()
+{
+    if (m_Index + sizeof(uint8_t) > m_Count)
+    {
+        throw std::out_of_range("BitReader::ReadUInt8");
+    }
+
+    uint8_t value = m_Data[m_Index];
+    m_Index += sizeof(uint8_t);
+    return value;
+}
+
+uint16_t BitReader::ReadUInt16()
+{
+    if (m_Index + sizeof(uint16_t) > m_Count)
+    {
+        throw std::out_of_range("BitReader::ReadUInt16");
+    }
+
+    uint16_t value = *reinterpret_cast<uint16_t*>(&m_Data[m_Index]);
+    m_Index += sizeof(uint16_t);
+    return value;
+}
+
+uint32_t BitReader::ReadUInt32()
+{
+    if (m_Index + sizeof(uint32_t) > m_Count)
+    {
+        throw std::out_of_range("BitReader::ReadUInt32");
+    }
+
+    uint32_t value = *reinterpret_cast<uint32_t*>(&m_Data[m_Index]);
+    m_Index += sizeof(uint32_t);
+    return value;
+}
+} // namespace gore

--- a/src/Utilities/BitReader.cpp
+++ b/src/Utilities/BitReader.cpp
@@ -4,10 +4,10 @@
 
 namespace gore
 {
-BitReader::BitReader(void* data, size_t count)
-    : m_Data(reinterpret_cast<uint8_t*>(data), reinterpret_cast<uint8_t*>(data) + count)
-    , m_Count(count)
-    , m_Index(0)
+BitReader::BitReader(void* data, size_t byteCount) :
+    m_Data(reinterpret_cast<uint8_t*>(data), reinterpret_cast<uint8_t*>(data) + byteCount),
+    m_Count(byteCount),
+    m_Index(0)
 {
 }
 

--- a/src/Utilities/BitReader.h
+++ b/src/Utilities/BitReader.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <vector>
+
+namespace gore
+{
+struct BitReader
+{
+};
+} // namespace gore

--- a/src/Utilities/BitReader.h
+++ b/src/Utilities/BitReader.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <vector>
+#include <span>
 
 namespace gore
 {
@@ -17,7 +17,7 @@ public:
     size_t GetBitsRead() const { return m_Index * 8; }
 
 private:
-    std::vector<uint8_t> m_Data;
+    std::span<uint8_t> m_Data;
     size_t m_Count;
     size_t m_Index;
 };

--- a/src/Utilities/BitReader.h
+++ b/src/Utilities/BitReader.h
@@ -5,5 +5,20 @@ namespace gore
 {
 struct BitReader
 {
+public:
+    BitReader(void* data, size_t count);
+
+    uint8_t ReadUInt8();
+    uint16_t ReadUInt16();
+    uint32_t ReadUInt32();
+
+    size_t GetBitsCount() const { return m_Count * 8; }
+    size_t GetBitsRemaining() const { return (m_Count - m_Index) * 8; }
+    size_t GetBitsRead() const { return m_Index * 8; }
+
+private:
+    std::vector<uint8_t> m_Data;
+    size_t m_Count;
+    size_t m_Index;
 };
-} // namespace gore
+} // namespace gore 

--- a/src/Utilities/BitReader.h
+++ b/src/Utilities/BitReader.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <span>
+#include <cstring>
+#include <stdexcept>
 
 namespace gore
 {
@@ -12,6 +14,20 @@ public:
     uint16_t ReadUInt16();
     uint32_t ReadUInt32();
 
+    template <typename T>
+    T Read()
+    {
+        size_t size = sizeof(T);
+        if (m_Index + size > m_Count)
+        {
+            throw std::runtime_error("BitReader overflow");
+        }
+        T value;
+        std::memcpy(&value, &m_Data[m_Index], size);
+        m_Index += size;
+        return value;
+    }
+
     size_t GetBitsCount() const { return m_Count * 8; }
     size_t GetBitsRemaining() const { return (m_Count - m_Index) * 8; }
     size_t GetBitsRead() const { return m_Index * 8; }
@@ -21,4 +37,4 @@ private:
     size_t m_Count;
     size_t m_Index;
 };
-} // namespace gore 
+} // namespace gore

--- a/src/Utilities/BitReader.h
+++ b/src/Utilities/BitReader.h
@@ -8,7 +8,7 @@ namespace gore
 struct BitReader
 {
 public:
-    BitReader(void* data, size_t count);
+    BitReader(void* data, size_t byteCount);
 
     uint8_t ReadUInt8();
     uint16_t ReadUInt16();

--- a/src/Utilities/BitWriter.cpp
+++ b/src/Utilities/BitWriter.cpp
@@ -11,11 +11,11 @@ BitWriter::BitWriter(void* data, size_t size) :
     m_Data.assign(static_cast<uint8_t*>(data), static_cast<uint8_t*>(data) + size);
 }
 
-BitWriter::BitWriter(size_t maxBitsCount, bool allowResize) :
+BitWriter::BitWriter(size_t maxByteCount, bool allowResize) :
     m_AllowResize(allowResize),
     m_Index(0)
 {
-    m_Data.resize(maxBitsCount / 8);
+    m_Data.resize(maxByteCount);
 }
 
 void BitWriter::WriteUInt8(uint8_t value)

--- a/src/Utilities/BitWriter.cpp
+++ b/src/Utilities/BitWriter.cpp
@@ -1,0 +1,42 @@
+#include "BitWriter.h"
+
+#include <stdexcept>
+
+namespace gore
+{
+BitWriter::BitWriter(size_t maxBitsCount, bool allowResize) :
+    m_AllowResize(allowResize),
+    m_Index(0)
+{
+    m_Data.resize(maxBitsCount / 8);
+}
+
+void BitWriter::WriteUInt8(uint8_t value)
+{
+    if (m_Index >= m_Data.size())
+    {
+        if (!m_AllowResize)
+        {
+            std::out_of_range("BitWriter Out of space");
+            return;
+        }
+
+        m_Data.resize(m_Data.size() * 2);
+    }
+
+    m_Data[m_Index++] = value;
+}
+
+void BitWriter::WriteUInt16(uint16_t value)
+{
+    WriteUInt8(value & 0xFF);
+    WriteUInt8((value >> 8) & 0xFF);
+}
+
+void BitWriter::WriteUInt32(uint32_t value)
+{
+    WriteUInt16(value & 0xFFFF);
+    WriteUInt16((value >> 16) & 0xFFFF);
+}
+
+} // namespace gore

--- a/src/Utilities/BitWriter.cpp
+++ b/src/Utilities/BitWriter.cpp
@@ -4,6 +4,13 @@
 
 namespace gore
 {
+BitWriter::BitWriter(void* data, size_t size) :
+    m_AllowResize(false),
+    m_Index(0)
+{
+    m_Data.assign(static_cast<uint8_t*>(data), static_cast<uint8_t*>(data) + size);
+}
+
 BitWriter::BitWriter(size_t maxBitsCount, bool allowResize) :
     m_AllowResize(allowResize),
     m_Index(0)

--- a/src/Utilities/BitWriter.h
+++ b/src/Utilities/BitWriter.h
@@ -14,6 +14,8 @@ public:
     void Flush() { m_Index = 0; }
     void ShrinkToFit() { m_Data.resize(m_Index); }
 
+    uint8_t* GetData() { return m_Data.data(); }
+
     void WriteUInt8(uint8_t value);
     void WriteUInt16(uint16_t value);
     void WriteUInt32(uint32_t value);
@@ -39,9 +41,9 @@ public:
     
     bool IsAllowResize() const { return m_AllowResize; }
     
-    size_t GetBitsCount() const { return m_Data.size() * 8; }
-    size_t GetBitsWritten() const { return m_Index * 8; }
-    size_t GetBitsRemaining() const { return GetBitsCount() - GetBitsWritten(); }
+    size_t GetByteCount() const { return m_Data.size(); }
+    size_t GetByteWritten() const { return m_Index; }
+    size_t GetByteRemaining() const { return GetByteCount() - GetByteWritten(); }
 
 private:
     bool m_AllowResize;

--- a/src/Utilities/BitWriter.h
+++ b/src/Utilities/BitWriter.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <vector>
+#include <cstring>
+#include <stdexcept>
 
 namespace gore
 {
@@ -11,6 +13,25 @@ public:
     void WriteUInt8(uint8_t value);
     void WriteUInt16(uint16_t value);
     void WriteUInt32(uint32_t value);
+
+    template <typename T>
+    void Write(const T& value)
+    {
+        size_t size = sizeof(T);
+        if (m_Index + size > m_Data.size())
+        {
+            if (m_AllowResize)
+            {
+                m_Data.resize(m_Index + size);
+            }
+            else
+            {
+                throw std::runtime_error("BitWriter overflow");
+            }
+        }
+        std::memcpy(&m_Data[m_Index], &value, size);
+        m_Index += size;
+    }
     
     bool IsAllowResize() const { return m_AllowResize; }
     

--- a/src/Utilities/BitWriter.h
+++ b/src/Utilities/BitWriter.h
@@ -5,5 +5,23 @@ namespace gore
 {
 struct BitWriter
 {
+public:
+    BitWriter(size_t maxBitsCount, bool allowResize = false);
+
+    void WriteUInt8(uint8_t value);
+    void WriteUInt16(uint16_t value);
+    void WriteUInt32(uint32_t value);
+    
+    bool IsAllowResize() const { return m_AllowResize; }
+    
+    size_t GetBitsCount() const { return m_Data.size() * 8; }
+    size_t GetBitsWritten() const { return m_Index * 8; }
+    size_t GetBitsRemaining() const { return GetBitsCount() - GetBitsWritten(); }
+
+private:
+    bool m_AllowResize;
+
+    std::vector<uint8_t> m_Data;
+    size_t m_Index;
 };
 } // namespace gore

--- a/src/Utilities/BitWriter.h
+++ b/src/Utilities/BitWriter.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <vector>
+
+namespace gore
+{
+struct BitWriter
+{
+};
+} // namespace gore

--- a/src/Utilities/BitWriter.h
+++ b/src/Utilities/BitWriter.h
@@ -9,6 +9,10 @@ struct BitWriter
 {
 public:
     BitWriter(size_t maxBitsCount, bool allowResize = false);
+    BitWriter(void* data, size_t size);
+
+    void Flush() { m_Index = 0; }
+    void ShrinkToFit() { m_Data.resize(m_Index); }
 
     void WriteUInt8(uint8_t value);
     void WriteUInt16(uint16_t value);

--- a/src/Utilities/BitWriter.h
+++ b/src/Utilities/BitWriter.h
@@ -8,7 +8,7 @@ namespace gore
 struct BitWriter
 {
 public:
-    BitWriter(size_t maxBitsCount, bool allowResize = false);
+    BitWriter(size_t maxByteCount, bool allowResize = false);
     BitWriter(void* data, size_t size);
 
     void Flush() { m_Index = 0; }


### PR DESCRIPTION
# **Land Draw Stream**

<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->

## **Description**

<!--  📛📛
Please include a summary of the change and/or which issue is fixed.
List any dependencies required for this change, if there are any.
📛📛 -->

* Draw stream is packed data layout for device to schedule draw calls

---

### **Additional context**

<!-- Add any other context or additional information about the pull request.-->

* Haven't test 2 draw calls...

### **Possible issues**

* 2 draw calls would cause crash?
<!-- 📛📛📛📛
If it fixes any current issue please let us know this way:
Uncomment the comment above "description", then add your number of issues after the "#".
Example: # **This pull request fixes #NUMBER_OF_THE_ISSUE issue**
If there are multiple issues to be closed with the merge of this pull request
please do it like so: **This pull request fixes #NUMBER_OF_THE_ISSUE, fixes #NUMBER_OF_THE_ISSUE and fixes #NUMBER_OF_THE_ISSUE issue**.
For more information on closing issues using keywords, please check https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#closing-multiple-issues
📛📛📛📛 -->