### PR TITLE
Implement ImGui rendering support with Vulkan

### DIFF
--- a/src/Rendering/RenderSystem.cpp
+++ b/src/Rendering/RenderSystem.cpp
@@ -502,7 +502,7 @@ void RenderSystem::InitImgui()
     renderPassInfo.pAttachments = &attachmentDesc;
     renderPassInfo.subpassCount = 1;
     renderPassInfo.pSubpasses = &subpassDesc;
-    m_ImGuiObjects.renderPass = m_Device.Get().createRenderPass(renderPassInfo);
+    m_ImGuiObjects.renderPass = (*m_Device.Get()).createRenderPass(renderPassInfo);
 
 	//this initializes imgui for Vulkan
 	ImGui_ImplVulkan_InitInfo init_info = {};
@@ -530,7 +530,7 @@ void RenderSystem::InitImgui()
     for (uint32_t i = 0; i < m_Swapchain.GetImageCount(); i++)
     {
         framebufferInfo.pAttachments = &(*m_Swapchain.GetImageViews()[i]);
-        m_ImGuiObjects.framebuffers[i] = m_Device.Get().createFramebuffer(framebufferInfo);
+        m_ImGuiObjects.framebuffers[i] = (*m_Device.Get()).createFramebuffer(framebufferInfo);
     }
 }
 

--- a/src/Rendering/RenderSystem.cpp
+++ b/src/Rendering/RenderSystem.cpp
@@ -481,7 +481,7 @@ void RenderSystem::InitImgui()
     vk::AttachmentDescription attachmentDesc = {};
     attachmentDesc.format = m_Swapchain.GetFormat().format;
     attachmentDesc.samples = vk::SampleCountFlagBits::e1;
-    attachmentDesc.loadOp = vk::AttachmentLoadOp::eClear;
+    attachmentDesc.loadOp = vk::AttachmentLoadOp::eLoad;
     attachmentDesc.storeOp = vk::AttachmentStoreOp::eStore;
     attachmentDesc.stencilLoadOp = vk::AttachmentLoadOp::eDontCare;
     attachmentDesc.stencilStoreOp = vk::AttachmentStoreOp::eDontCare;

--- a/src/Rendering/RenderSystem.cpp
+++ b/src/Rendering/RenderSystem.cpp
@@ -621,7 +621,13 @@ void RenderSystem::RunRpsSystem()
 
     ResetCommandPools();
 
-    ExecuteRenderGraph(m_FrameCounter, *m_RpsSystem->rpsRDG);
+    ExecuteRenderGraph(m_FrameCounter, *m_RpsSystem->rpsRDG, true, false);
+
+    StartImguiDraw();
+
+    DrawImgui();
+
+    EndImguiDraw(*m_RpsSystem->rpsRDG);
 
     vk::PresentInfoKHR presentInfo = {};
     presentInfo.swapchainCount   = 1;
@@ -764,7 +770,8 @@ void RenderSystem::StartImguiDraw()
 
 void RenderSystem::DrawImgui()
 {
-
+    bool show = true;
+    ImGui::ShowDemoWindow(&show);
 }
 
 void RenderSystem::EndImguiDraw(RpsRenderGraph renderGraph)
@@ -782,7 +789,7 @@ void RenderSystem::EndImguiDraw(RpsRenderGraph renderGraph)
     graphToGuiBarrier.srcAccessMask = {};
     graphToGuiBarrier.dstAccessMask = vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite;
     graphToGuiBarrier.oldLayout =
-        m_FrameCounter < m_Swapchain.GetImageCount() ? vk::ImageLayout::eUndefined : vk::ImageLayout::eColorAttachmentOptimal;
+        m_FrameCounter < m_Swapchain.GetImageCount() ? vk::ImageLayout::eUndefined : vk::ImageLayout::ePresentSrcKHR;
     graphToGuiBarrier.newLayout                   = vk::ImageLayout::eColorAttachmentOptimal;
     graphToGuiBarrier.image                       = m_Swapchain.GetImages()[m_backBufferIndex];
     graphToGuiBarrier.subresourceRange.aspectMask = vk::ImageAspectFlagBits::eColor;

--- a/src/Rendering/RenderSystem.h
+++ b/src/Rendering/RenderSystem.h
@@ -104,6 +104,9 @@ private:
     void InitImgui();
     void ShutdownImgui();
     
+    void CreateImGuiFramebuffer();
+    void DestroyImGuiFramebuffer();
+
     struct ImGuiObjects
     {
         vk::RenderPass renderPass                 = {};

--- a/src/Rendering/RenderSystem.h
+++ b/src/Rendering/RenderSystem.h
@@ -103,6 +103,16 @@ private:
     // Imgui
     void InitImgui();
     void ShutdownImgui();
+    
+    struct ImGuiObjects
+    {
+        vk::RenderPass renderPass                 = {};
+        std::vector<vk::Framebuffer> framebuffers = {};
+    } m_ImGuiObjects;
+
+    void StartImguiDraw();
+    void DrawImgui();
+    void EndImguiDraw(RpsRenderGraph renderGraph);
 
     ImGui_ImplVulkanH_Window m_ImguiWindowData;
     vk::raii::DescriptorPool m_ImguiDescriptorPool;


### PR DESCRIPTION
Introduce Vulkan render pass and framebuffer management for ImGui integration. Enhance the rendering process with updated handling in the render graph and add methods for framebuffer creation and destruction. Fix issues related to device pointer dereferencing and attachment load operations.